### PR TITLE
Update most references of vector-im to element-hq

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Enhancement or feature request
-    url: https://github.com/vector-im/element-meta/discussions/categories/ideas
+    url: https://github.com/element-hq/element-meta/discussions/categories/ideas
     about: Do you have a suggestion or feature request?
   - name: Element iOS Community Support
     url: https://matrix.to/#/#element-ios:matrix.org

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Pull Request Checklist
 
-- [ ] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
+- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md)
 - [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
 - [ ] Accessibility has been taken into account.
 * [ ] Pull request is based on the develop branch

--- a/.github/workflows/triage-incoming.yml
+++ b/.github/workflows/triage-incoming.yml
@@ -17,7 +17,7 @@ jobs:
   add_to_triage:
     runs-on: ubuntu-latest
     if: >
-      github.repository == 'vector-im/element-ios'
+      github.repository == 'element-hq/element-ios'
     steps:
       - uses: octokit/graphql-action@v2.x
         with:

--- a/.github/workflows/triage-move-labelled.yml
+++ b/.github/workflows/triage-move-labelled.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: konradpabjan/move-labeled-or-milestoned-issue@219d384e03fa4b6460cd24f9f37d19eb033a4338
         with:
           action-token: "${{ secrets.ELEMENT_BOT_TOKEN }}"
-          project-url: "https://github.com/vector-im/element-ios/projects/12"
+          project-url: "https://github.com/element-hq/element-ios/projects/12"
           column-name: "Need info"
           label-name: "X-Needs-Info"
 
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/vector-im/projects/18
+          project-url: https://github.com/orgs/element-hq/projects/18
           github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
   add_product_issues_to_project:
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/vector-im/projects/28
+          project-url: https://github.com/orgs/element-hq/projects/28
           github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
   ex_plorers:
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/vector-im/projects/73
+          project-url: https://github.com/orgs/element-hq/projects/73
           github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
   ps_features1:
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/vector-im/projects/56
+          project-url: https://github.com/orgs/element-hq/projects/56
           github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
   ps_features2:
@@ -105,7 +105,7 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/vector-im/projects/58
+          project-url: https://github.com/orgs/element-hq/projects/58
           github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
   ps_features3:
@@ -116,7 +116,7 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/vector-im/projects/57
+          project-url: https://github.com/orgs/element-hq/projects/57
           github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
 
   voip:
@@ -127,5 +127,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/vector-im/projects/41
+          project-url: https://github.com/orgs/element-hq/projects/41
           github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}

--- a/.github/workflows/triage-review-requests.yml
+++ b/.github/workflows/triage-review-requests.yml
@@ -14,7 +14,7 @@ jobs:
           headers: '{"GraphQL-Features": "projects_next_graphql"}'
           query: |
             query find_team_members($team: String!) {
-              organization(login: "vector-im") {
+              organization(login: "element-hq") {
                 team(slug: $team) {
                   members {
                     nodes {
@@ -81,7 +81,7 @@ jobs:
           headers: '{"GraphQL-Features": "projects_next_graphql"}'
           query: |
             query find_team_members($team: String!) {
-              organization(login: "vector-im") {
+              organization(login: "element-hq") {
                 team(slug: $team) {
                   members {
                     nodes {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Please read the matrix-ios-sdk [contributing guide](https://github.com/matrix-or
 ## I want to help translating
 
 If you want to fix an issue for an English string, please submit a pull request to the Element iOS GitHub repository.
-If you want to fix an issue for another language, add a missing translation, or  add a new language, please read [Element Web translating guide](https://github.com/vector-im/element-web/blob/develop/docs/translating.md) first and then use the Element iOS [Weblate](https://translate.riot.im/projects/riot-ios/).
+If you want to fix an issue for another language, add a missing translation, or  add a new language, please read [Element Web translating guide](https://github.com/element-hq/element-web/blob/develop/docs/translating.md) first and then use the Element iOS [Weblate](https://translate.riot.im/projects/riot-ios/).
 
 If you have any question regarding translations please ask in [Element Translation room](https://matrix.to/#/#element-translations:matrix.org).
 
@@ -26,7 +26,7 @@ Otherwise please have a look to [Apple Swift conventions](https://swift.org/docu
 
 ## Pull request
 
-When you are making a pull request please read carefully the [Pull Request Checklist](https://github.com/vector-im/element-ios/blob/develop/.github/PULL_REQUEST_TEMPLATE.md).
+When you are making a pull request please read carefully the [Pull Request Checklist](https://github.com/element-hq/element-ios/blob/develop/.github/PULL_REQUEST_TEMPLATE.md).
 
 ## Thanks
 

--- a/Podfile
+++ b/Podfile
@@ -122,7 +122,7 @@ abstract_target 'RiotPods' do
   end
 
   # Disabled due to crypto corruption issues.
-  # https://github.com/vector-im/element-ios/issues/7618
+  # https://github.com/element-hq/element-ios/issues/7618
   # target "RiotShareExtension" do
   #   import_MatrixSDK
   #   import_MatrixKit_pods

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Element iOS
 
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/vector-im/element-ios)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/element-hq/element-ios)
 ![badge-languages](https://img.shields.io/badge/languages-Swift%20%7C%20ObjC-orange.svg)
 [![Swift 5.x](https://img.shields.io/badge/Swift-5.x-orange)](https://developer.apple.com/swift)
 [![Build status](https://badge.buildkite.com/cc8f93e32da93fa7c1172398bd8af66254490567c7195a5f3f.svg?branch=develop)](https://buildkite.com/matrix-dot-org/element-ios/builds?branch=develop)
 [![Weblate](https://translate.riot.im/widgets/riot-ios/-/svg-badge.svg)](https://translate.riot.im/engage/riot-ios/?utm_source=widget)
-[![codecov](https://codecov.io/gh/vector-im/element-ios/branch/develop/graph/badge.svg?token=INNm5o6XWg)](https://codecov.io/gh/vector-im/element-ios)
+[![codecov](https://codecov.io/gh/element-hq/element-ios/branch/develop/graph/badge.svg?token=INNm5o6XWg)](https://codecov.io/gh/element-hq/element-ios)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=vector-im_element-ios&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=vector-im_element-ios)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=vector-im_element-ios&metric=bugs)](https://sonarcloud.io/summary/new_code?id=vector-im_element-ios)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=vector-im_element-ios&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=vector-im_element-ios)
 [![Element iOS Matrix room #element-ios:matrix.org](https://img.shields.io/matrix/element-ios:matrix.org.svg?label=%23element-ios:matrix.org&logo=matrix&server_fqdn=matrix.org)](https://matrix.to/#/#element-ios:matrix.org)
-![GitHub](https://img.shields.io/github/license/vector-im/element-ios)
+![GitHub](https://img.shields.io/github/license/element-hq/element-ios)
 [![Twitter URL](https://img.shields.io/twitter/url?label=Element&url=https%3A%2F%2Ftwitter.com%2Felement_hq)](https://twitter.com/element_hq)
 
 Element iOS is an iOS [Matrix](https://matrix.org/) client provided by [Element](https://element.io/). It is based on [MatrixSDK](https://github.com/matrix-org/matrix-ios-sdk).
@@ -43,7 +43,7 @@ If you want to contribute to Element iOS code or translations, go to the [contri
 
 ## Support
 
-When you are experiencing an issue on Element iOS, please first search in [GitHub issues](https://github.com/vector-im/element-ios/issues)
+When you are experiencing an issue on Element iOS, please first search in [GitHub issues](https://github.com/element-hq/element-ios/issues)
 and then in [#element-ios:matrix.org](https://matrix.to/#/#element-ios:matrix.org).
 If after your research you still have a question, ask at [#element-ios:matrix.org](https://matrix.to/#/#element-ios:matrix.org). Otherwise feel free to create a GitHub issue if you encounter a bug or a crash, by explaining clearly in detail what happened. You can also perform bug reporting (Rageshake) from the Element application by shaking your phone or going to the application settings. This is especially recommended when you encounter a crash.
 

--- a/Riot/Assets/third_party_licenses.html
+++ b/Riot/Assets/third_party_licenses.html
@@ -1703,7 +1703,7 @@
     
     <li>
         <b>swift-ogg</b> (<a
-            href="https://github.com/vector-im/swift-ogg">https://github.com/vector-im/swift-ogg</a>)
+            href="https://github.com/element-hq/swift-ogg">https://github.com/element-hq/swift-ogg</a>)
         <p>Makes use of code from 5 frameworks:<br/></p>
         <ul>
             <li>

--- a/Riot/target.yml
+++ b/Riot/target.yml
@@ -35,7 +35,7 @@ targets:
 
     dependencies:
     # Disabled due to crypto corruption issues.
-    # https://github.com/vector-im/element-ios/issues/7618
+    # https://github.com/element-hq/element-ios/issues/7618
     # - target: RiotShareExtension
     # - target: SiriIntents
     - target: RiotNSE

--- a/changelog.d/_template.md.jinja
+++ b/changelog.d/_template.md.jinja
@@ -1,7 +1,7 @@
 {# iOS Repositories #}
 {%- set gh_sdk = "https://github.com/matrix-org/matrix-ios-sdk" -%}
 {%- set gh_kit = "https://github.com/matrix-org/matrix-ios-kit" -%}
-{%- set gh_element = "https://github.com/vector-im/element-ios" -%}
+{%- set gh_element = "https://github.com/element-hq/element-ios" -%}
 
 ## {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
 {% for section, _ in sections.items() %}

--- a/docs/Customisation.md
+++ b/docs/Customisation.md
@@ -14,4 +14,4 @@ Various features of Element iOS can be enabled/disabled/configured via flags in 
 
 The themes used in Element iOS can be found in `Riot/Managers/Theme/Themes`. A newer theming system is available as nested `colors` and `fonts` properties on these themes and can be found in `DesignKit/Variants/Colors` and `DesignKit/Variants/Fonts` respectively. The newer system is used for screens built in UIKit with Swift and all of the SwiftUI screens.
 
-For logos, they're currently regular assets that can be found either in [Images.xcassets](https://github.com/vector-im/element-ios/tree/develop/Riot/Assets/Images.xcassets) or [SharedImages.xcassets](https://github.com/vector-im/element-ios/tree/develop/Riot/Assets/SharedImages.xcassets).
+For logos, they're currently regular assets that can be found either in [Images.xcassets](https://github.com/element-hq/element-ios/tree/develop/Riot/Assets/Images.xcassets) or [SharedImages.xcassets](https://github.com/element-hq/element-ios/tree/develop/Riot/Assets/SharedImages.xcassets).

--- a/project.yml
+++ b/project.yml
@@ -38,7 +38,7 @@ include:
   - path: CommonKit/target.yml
   - path: CommonKit/targetUnitTests.yml
   # Disabled due to crypto corruption issues.
-  # https://github.com/vector-im/element-ios/issues/7618
+  # https://github.com/element-hq/element-ios/issues/7618
   # - path: RiotShareExtension/target.yml
   # - path: SiriIntents/target.yml
 
@@ -55,7 +55,7 @@ packages:
     minVersion: 1.0.2
     maxVersion: 2.0.0
   SwiftOGG:
-    url: https://github.com/vector-im/swift-ogg
+    url: https://github.com/element-hq/swift-ogg
     branch: 0.0.1
   WysiwygComposer:
     url: https://github.com/matrix-org/matrix-wysiwyg-composer-swift


### PR DESCRIPTION
Ignoring code comments as the codebase is old and redirects exist. Might be some Sonarcloud updates to follow.