### PR TITLE
Fix for swapped accessibility labels for the underline and the strikethrough on RTE

### DIFF
--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -2617,8 +2617,8 @@ To enable access, tap Settings> Location and select Always";
 // Formatting Actions
 "wysiwyg_composer_format_action_bold" = "Apply bold format";
 "wysiwyg_composer_format_action_italic" = "Apply italic format";
-"wysiwyg_composer_format_action_underline" = "Apply strikethrough format";
-"wysiwyg_composer_format_action_strikethrough" = "Apply underline format";
+"wysiwyg_composer_format_action_underline" = "Apply underline format";
+"wysiwyg_composer_format_action_strikethrough" = "Apply strikethrough format";
 "wysiwyg_composer_format_action_link" = "Apply link format";
 "wysiwyg_composer_format_action_inline_code" = "Apply inline code format";
 "wysiwyg_composer_format_action_unordered_list" = "Toggle bulleted list";

--- a/changelog.d/pr-7743.bugfix
+++ b/changelog.d/pr-7743.bugfix
@@ -1,0 +1,1 @@
+Fix swapped accessibility label between strikethrough and underline format buttons in RTE.


### PR DESCRIPTION
The code was fine, but the provided original copies were swapped, so we needed to change them in the original english string file. Now this change needs to be propagated through weblate for all the other languages.