### PR TITLE
Fix a bug where QR codes aren't detected if the camera is too close.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -59,7 +59,7 @@ end
 def import_SwiftUI_pods
     pod 'Introspect', '~> 0.1'
     pod 'DSBottomSheet', '~> 0.3'
-    pod 'ZXingObjC', '~> 3.6.5'
+    pod 'ZXingObjC', '~> 3.6.9'
 end
 
 abstract_target 'RiotPods' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -87,9 +87,9 @@ PODS:
   - UICollectionViewRightAlignedLayout (0.0.3)
   - WeakDictionary (2.0.2)
   - zxcvbn-ios (1.0.4)
-  - ZXingObjC (3.6.5):
-    - ZXingObjC/All (= 3.6.5)
-  - ZXingObjC/All (3.6.5)
+  - ZXingObjC (3.6.9):
+    - ZXingObjC/All (= 3.6.9)
+  - ZXingObjC/All (3.6.9)
 
 DEPENDENCIES:
   - Down (~> 0.11.0)
@@ -119,7 +119,7 @@ DEPENDENCIES:
   - UICollectionViewRightAlignedLayout (~> 0.0.3)
   - WeakDictionary (~> 2.0)
   - zxcvbn-ios
-  - ZXingObjC (~> 3.6.5)
+  - ZXingObjC (~> 3.6.9)
 
 SPEC REPOS:
   trunk:
@@ -206,8 +206,8 @@ SPEC CHECKSUMS:
   UICollectionViewRightAlignedLayout: 823eef8c567eba4a44c21bc2ffcb0d0d5f361e2d
   WeakDictionary: 8cd038acd77e5d54ca4ebaec3d20853d732b45e0
   zxcvbn-ios: fef98b7c80f1512ff0eec47ac1fa399fc00f7e3c
-  ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
+  ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: 9245f34ec35d24a0993d1a16faa145cf3094a1b2
+PODFILE CHECKSUM: c87b532985dd755b373732f841e3bcfe616f4e4f
 
 COCOAPODS: 1.14.3

--- a/Riot/Modules/QRCode/Reader/QRCodeReaderView.swift
+++ b/Riot/Modules/QRCode/Reader/QRCodeReaderView.swift
@@ -113,7 +113,6 @@ final class QRCodeReaderView: UIView {
     }
 
     private func applyOrientation() {
-        
         let orientation = UIApplication.shared.statusBarOrientation
         let captureRotation: Double
         let scanRectRotation: Double
@@ -136,58 +135,12 @@ final class QRCodeReaderView: UIView {
             scanRectRotation = 90
         }
         
-        applyRectOfInterest(orientation: orientation)
-        
         let angleRadius = captureRotation / 180.0 * Double.pi
-        let captureTranform = CGAffineTransform(rotationAngle: CGFloat(angleRadius))
+        let captureTransform = CGAffineTransform(rotationAngle: CGFloat(angleRadius))
         
-        zxCapture.transform = captureTranform
+        zxCapture.transform = captureTransform
         zxCapture.rotation = CGFloat(scanRectRotation)
         zxCapture.layer.frame = self.bounds
-    }
-    
-    private func applyRectOfInterest(orientation: UIInterfaceOrientation) {
-        var transformedVideoRect = self.frame
-        let cameraSessionPreset = zxCapture.sessionPreset
-        
-        var scaleVideoX, scaleVideoY: CGFloat
-        var videoHeight, videoWidth: CGFloat
-        
-        // Currently support only for 1920x1080 || 1280x720
-        if cameraSessionPreset == AVCaptureSession.Preset.hd1920x1080.rawValue {
-            videoHeight = 1080.0
-            videoWidth = 1920.0
-        } else {
-            videoHeight = 720.0
-            videoWidth = 1280.0
-        }
-        
-        if orientation == UIInterfaceOrientation.portrait {
-            scaleVideoX = self.frame.width / videoHeight
-            scaleVideoY = self.frame.height / videoWidth
-            
-            // Convert CGPoint under portrait mode to map with orientation of image
-            // because the image will be cropped before rotate
-            // reference: https://github.com/TheLevelUp/ZXingObjC/issues/222
-            let realX = transformedVideoRect.origin.y
-            let realY = self.frame.size.width - transformedVideoRect.size.width - transformedVideoRect.origin.x
-            let realWidth = transformedVideoRect.size.height
-            let realHeight = transformedVideoRect.size.width
-            transformedVideoRect = CGRect(x: realX, y: realY, width: realWidth, height: realHeight)
-            
-        } else {
-            scaleVideoX = self.frame.width / videoWidth
-            scaleVideoY = self.frame.height / videoHeight
-        }
-        
-        captureSizeTransform = CGAffineTransform(scaleX: 1.0/scaleVideoX, y: 1.0/scaleVideoY)
-        
-        guard let _captureSizeTransform = captureSizeTransform else {
-            return
-        }
-        
-        let transformRect = transformedVideoRect.applying(_captureSizeTransform)
-        zxCapture.scanRect = transformRect
     }
 }
 

--- a/changelog.d/pr-7762.bugfix
+++ b/changelog.d/pr-7762.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where QR codes aren't detected if the camera is too close.


### PR DESCRIPTION
There were reports about not being able to scan QR codes to verify a device, but it turns out that it does work, just not if you fill the entire frame with the code. Moving back a bit so the code is smaller does work.

My conclusion was that the `applyRectOfInterest` method isn't really necessary as we don't do that when [logging in](https://github.com/element-hq/element-ios/blob/b39923fbc1b047494a5d01e13e24501b661343bd/RiotSwiftUI/Modules/Authentication/QRLogin/Common/Service/MatrixSDK/QRLoginService.swift#L30) with a QR code. The removal of that method has no effect on the UI, it simply constrained the area of the capture that ZXing was looking in.