### PR TITLE
Analytics | permanent vs temporary utd

### DIFF
--- a/Riot/Modules/Analytics/Analytics.swift
+++ b/Riot/Modules/Analytics/Analytics.swift
@@ -215,7 +215,7 @@ import AnalyticsEvents
 
 @objc
 protocol E2EAnalytics {
-    func trackE2EEError(_ reason: DecryptionFailureReason, context: String)
+    func trackE2EEError(_ failure: DecryptionFailure)
 }
 
 
@@ -225,21 +225,8 @@ protocol E2EAnalytics {
     /// - Parameters:
     ///   - reason: The error that occurred.
     ///   - context: Additional context of the error that occured
-    func trackE2EEError(_ reason: DecryptionFailureReason, context: String) {
-        let event = AnalyticsEvent.Error(
-            context: context,
-            cryptoModule: .Rust,
-            cryptoSDK: AnalyticsEvent.Error.CryptoSDK.Rust,
-            domain: .E2EE,
-            // XXX not yet supported.
-            eventLocalAgeMillis: nil,
-            isFederated: nil,
-            isMatrixDotOrg: nil,
-            name: reason.errorName,
-            timeToDecryptMillis: nil,
-            userTrustsOwnIdentity: nil,
-            wasVisibleToUser: nil
-        )
+    func trackE2EEError(_ failure: DecryptionFailure) {
+        let event = failure.toAnalyticsEvent()
         capture(event: event)
     }
     

--- a/Riot/Modules/Analytics/DecryptionFailure+Analytics.swift
+++ b/Riot/Modules/Analytics/DecryptionFailure+Analytics.swift
@@ -1,0 +1,44 @@
+// 
+// Copyright 2024 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+import AnalyticsEvents
+
+extension DecryptionFailure {
+    
+    public func toAnalyticsEvent() -> AnalyticsEvent.Error {
+        
+        let timeToDecryptMillis: Int = if self.timeToDecrypt != nil {
+            Int(self.timeToDecrypt! * 1000)
+        } else {
+            -1
+        }
+        return AnalyticsEvent.Error(
+            context: self.context,
+            cryptoModule: .Rust,
+            cryptoSDK: .Rust,
+            domain: .E2EE,
+            
+            eventLocalAgeMillis: nil,
+            isFederated: nil,
+            isMatrixDotOrg: nil,
+            name: self.reason.errorName,
+            timeToDecryptMillis: timeToDecryptMillis,
+            userTrustsOwnIdentity: nil,
+            wasVisibleToUser: nil
+        )
+    }
+}

--- a/Riot/Modules/Analytics/DecryptionFailure.swift
+++ b/Riot/Modules/Analytics/DecryptionFailure.swift
@@ -44,6 +44,9 @@ import AnalyticsEvents
     /// Additional context of failure
     let context: String
     
+    /// UTDs can be permanent or temporary. If temporary, this field will contain the time it took to decrypt the message in milliseconds. If permanent should be nil
+    var timeToDecrypt: TimeInterval?
+    
     init(failedEventId: String, reason: DecryptionFailureReason, context: String, ts: TimeInterval) {
         self.failedEventId = failedEventId
         self.reason = reason

--- a/RiotTests/DecryptionFailureTrackerTests.swift
+++ b/RiotTests/DecryptionFailureTrackerTests.swift
@@ -290,6 +290,11 @@ class DecryptionFailureTrackerTests: XCTestCase {
         XCTAssertEqual(testDelegate.reportedFailure?.reason, DecryptionFailureReason.olmKeysNotSent);
         XCTAssertEqual(testDelegate.reportedFailure?.timeToDecrypt, TimeInterval(20));
         
+        // Assert that it's converted to millis for reporting
+        let analyticsError = testDelegate.reportedFailure!.toAnalyticsEvent()
+        
+        XCTAssertEqual(analyticsError.timeToDecryptMillis, 20000)
+        
     }
     
     
@@ -324,6 +329,12 @@ class DecryptionFailureTrackerTests: XCTestCase {
         // Event should have been reported as a late decrypt
         XCTAssertEqual(testDelegate.reportedFailure?.reason, DecryptionFailureReason.olmKeysNotSent);
         XCTAssertNil(testDelegate.reportedFailure?.timeToDecrypt);
+        
+        
+        // Assert that it's converted to -1 for reporting
+        let analyticsError = testDelegate.reportedFailure!.toAnalyticsEvent()
+        
+        XCTAssertEqual(analyticsError.timeToDecryptMillis, -1)
         
     }
 }


### PR DESCRIPTION
Preliminary work for https://github.com/element-hq/element-ios/issues/7767

depends on https://github.com/element-hq/element-ios/pull/7769


Add support for permanent vs temporary UTD.
If an event is decrypted in less than 4s after decryption, it should be graced.
If it's decrypted in > 4s and less than 60s, we still report as an UTD but with the time to decrypt.
If after 60s it's not decrypted report as permanent UTD

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [ ] Pull request is based on the develop branch
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ ] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
