### PR TITLE
Telemetry | Add additional properties to posthog UTD errors

### DIFF
--- a/Riot/Modules/Analytics/DecryptionFailure+Analytics.swift
+++ b/Riot/Modules/Analytics/DecryptionFailure+Analytics.swift
@@ -42,14 +42,13 @@ extension DecryptionFailure {
             cryptoModule: .Rust,
             cryptoSDK: .Rust,
             domain: .E2EE,
-            
             eventLocalAgeMillis: self.eventLocalAgeMillis,
-            isFederated: nil,
-            isMatrixDotOrg: nil,
+            isFederated: self.isFederated,
+            isMatrixDotOrg: self.isMatrixOrg,
             name: errorName,
             timeToDecryptMillis: timeToDecryptMillis,
             userTrustsOwnIdentity: self.trustOwnIdentityAtTimeOfFailure,
-            wasVisibleToUser: nil
+            wasVisibleToUser: self.wasVisibleToUser
         )
     }
 }

--- a/Riot/Modules/Analytics/DecryptionFailure.swift
+++ b/Riot/Modules/Analytics/DecryptionFailure.swift
@@ -52,6 +52,14 @@ import AnalyticsEvents
     
     var eventLocalAgeMillis: Int?
     
+    /// Is the current user on matrix org
+    var isMatrixOrg: Bool?
+    /// Are the sender and recipient on the same homeserver
+    var isFederated: Bool?
+    
+    /// As for now the ios App only reports UTDs visible to user (error are reported from EventFormatter
+    var wasVisibleToUser: Bool = true
+    
     init(failedEventId: String, reason: DecryptionFailureReason, context: String, ts: TimeInterval) {
         self.failedEventId = failedEventId
         self.reason = reason

--- a/Riot/Modules/Analytics/DecryptionFailureTracker.swift
+++ b/Riot/Modules/Analytics/DecryptionFailureTracker.swift
@@ -103,12 +103,12 @@ class DecryptionFailureTracker: NSObject {
         failure.eventLocalAgeMillis = Int(exactly: eventRelativeAgeMillis)
         failure.trustOwnIdentityAtTimeOfFailure = isSessionVerified
         
-        let myDomain = userId.components(separatedBy: ":")[1]
+        let myDomain = userId.components(separatedBy: ":").last
         failure.isMatrixOrg = myDomain == "matrix.org"
         
         if MXTools.isMatrixUserIdentifier(event.sender) {
-            let senderDomain = event.sender.components(separatedBy: ":")[1]
-            failure.isFederated = senderDomain != myDomain
+            let senderDomain = event.sender.components(separatedBy: ":").last
+            failure.isFederated = senderDomain != nil && senderDomain != myDomain
         }
         
         /// XXX for future work, as for now only the event formatter reports UTDs. That means that it's only UTD ~visible to users

--- a/Riot/Modules/Analytics/DecryptionFailureTracker.swift
+++ b/Riot/Modules/Analytics/DecryptionFailureTracker.swift
@@ -103,6 +103,17 @@ class DecryptionFailureTracker: NSObject {
         failure.eventLocalAgeMillis = Int(exactly: eventRelativeAgeMillis)
         failure.trustOwnIdentityAtTimeOfFailure = isSessionVerified
         
+        let myDomain = userId.components(separatedBy: ":")[1]
+        failure.isMatrixOrg = myDomain == "matrix.org"
+        
+        if MXTools.isMatrixUserIdentifier(event.sender) {
+            let senderDomain = event.sender.components(separatedBy: ":")[1]
+            failure.isFederated = senderDomain != myDomain
+        }
+        
+        /// XXX for future work, as for now only the event formatter reports UTDs. That means that it's only UTD ~visible to users
+        failure.wasVisibleToUser = true
+        
         reportedFailures[failedEventId] = failure
         
         


### PR DESCRIPTION
### Pull Request Checklist

Based on https://github.com/element-hq/element-ios/pull/7775

Last step of https://github.com/element-hq/element-ios/issues/7767

Add the new properties `isMatrixOrg`, `isFederated` and `wasVisibleToUser`.

Note: `wasVisibleToUser` is always true for now, as the UTD are reported only from the `EventFormatter`.
Additional work is needed to report visible vs not visible. This would require to move down the `DecryptionFailureTracker` into the SDK


- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [ ] Pull request is based on the develop branch
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ ] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
