### PR TITLE
Bump rich text editor version to 2.37.0 

### DIFF
--- a/Riot.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Riot.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -46,12 +46,12 @@
       }
     },
     {
-      "identity" : "matrix-wysiwyg-composer-swift",
+      "identity" : "matrix-rich-text-editor-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/matrix-org/matrix-wysiwyg-composer-swift",
+      "location" : "https://github.com/matrix-org/matrix-rich-text-editor-swift",
       "state" : {
-        "revision" : "f788fe2482c0b89019f679a1f43dccf9c25a0782",
-        "version" : "2.29.0"
+        "revision" : "dbcc0e3f5a466c7af0713f02030e4089d51e262e",
+        "version" : "2.37.0"
       }
     },
     {

--- a/changelog.d/7777.change
+++ b/changelog.d/7777.change
@@ -1,0 +1,1 @@
+Labs: Rich Text Editor: Upgrade to version to 2.37.0

--- a/project.yml
+++ b/project.yml
@@ -58,8 +58,8 @@ packages:
     url: https://github.com/element-hq/swift-ogg
     branch: 0.0.1
   WysiwygComposer:
-    url: https://github.com/matrix-org/matrix-wysiwyg-composer-swift
-    version: 2.29.0
+    url: https://github.com/matrix-org/matrix-rich-text-editor-swift
+    version: 2.37.0
   DeviceKit:
     url: https://github.com/devicekit/DeviceKit
     majorVersion: 4.7.0


### PR DESCRIPTION
Bumps matrix-wysiwyg-composer-swift version. The lib has also moved from `matrix-wysiwyg-composer-swift` to `matrix-rich-text-editor-swift`

### Pull Request Checklist

- [ ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [ ] Pull request is based on the develop branch
- [ ] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ ] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [ ] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
