### PR TITLE
Fix a crash when the user taps play multiple times and the download fails

### DIFF
--- a/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
+++ b/Riot/Modules/Room/Attachements/MXKAttachmentsViewController.m
@@ -107,6 +107,8 @@
 
 @property (nonatomic) BOOL customAnimationsEnabled;
 
+@property (nonatomic) BOOL isLoadingVideo;
+
 @end
 
 @implementation MXKAttachmentsViewController
@@ -969,8 +971,10 @@
                         navigationBarDisplayTimer = [NSTimer scheduledTimerWithTimeInterval:5 target:self selector:@selector(hideNavigationBar) userInfo:self repeats:NO];
                     }
                 }
-                else
+                else if (!self.isLoadingVideo)
                 {
+                    self.isLoadingVideo = YES;
+                    
                     MXKPieChartView *pieChartView = [[MXKPieChartView alloc] initWithFrame:CGRectMake(0, 0, 40, 40)];
                     pieChartView.progress = 0;
                     pieChartView.progressColor = [UIColor colorWithRed:1 green:1 blue:1 alpha:0.25];
@@ -1020,6 +1024,7 @@
                             [selectedCell.moviePlayer.player play];
                             
                             [pieChartView removeFromSuperview];
+                            self.isLoadingVideo = NO;
                             
                             [self hideNavigationBar];
                         }
@@ -1035,6 +1040,7 @@
                         MXLogDebug(@"[MXKAttachmentsVC] video download failed");
                         
                         [pieChartView removeFromSuperview];
+                        self.isLoadingVideo = NO;
                         
                         // Display the navigation bar so that the user can leave this screen
                         self.navigationBarContainer.hidden = NO;

--- a/changelog.d/7791.bugfix
+++ b/changelog.d/7791.bugfix
@@ -1,0 +1,1 @@
+Fix a crash when the user taps play multiple times and the video download fails.


### PR DESCRIPTION
Fixes #7791

The crash had nothing to do with the network failures, tapping play once and killing the network fails gracefully. However if the user tapped play multiple times, then the app would crash handling the failure multiple times.