### PR TITLE
Check power level before starting live sharing location

### DIFF
--- a/RiotSwiftUI/Modules/LocationSharing/StartLocationSharing/Coordinator/LocationSharingCoordinator.swift
+++ b/RiotSwiftUI/Modules/LocationSharing/StartLocationSharing/Coordinator/LocationSharingCoordinator.swift
@@ -166,17 +166,16 @@ final class LocationSharingCoordinator: Coordinator, Presentable {
     
     // Check if user can send beacon info state event
     private func canShareLiveLocation() -> Bool {
-        guard let myUserId = parameters.roomDataSource.mxSession.myUserId else {
+        guard let myUserId = parameters.roomDataSource.mxSession.myUserId,
+              let roomPowerLevels = parameters.roomDataSource.roomState.powerLevels,
+              let userPowerLevel = RoomPowerLevel(rawValue: roomPowerLevels.powerLevelOfUser(withUserID: myUserId)) else {
             return false
         }
         
-        let userPowerLevelRawValue = parameters.roomDataSource.roomState.powerLevels.powerLevelOfUser(withUserID: myUserId)
-        
-        guard let userPowerLevel = RoomPowerLevel(rawValue: userPowerLevelRawValue) else {
-            return false
-        }
-        
-        return userPowerLevel.rawValue >= RoomPowerLevel.moderator.rawValue
+        // CHeck user power level in room against power level needed to post geolocation state event.
+        let liveSharingPowerLevel = roomPowerLevels.minimumPowerLevelForSendingStateEvent(.beaconInfo)
+
+        return userPowerLevel.rawValue >= liveSharingPowerLevel
     }
     
     private func showLabFlagPromotionIfNeeded(completion: @escaping ((Bool) -> Void)) {

--- a/changelog.d/pr-7808.change
+++ b/changelog.d/pr-7808.change
@@ -1,0 +1,1 @@
+Check power level before starting live sharing location


### PR DESCRIPTION
#7808 cherry picked and squashed without the commits from #7778.

Original sign off is in the previous PR.