### PR TITLE
Show Matrix RTC calls as unsupported.

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -39,16 +39,16 @@ PODS:
   - LoggerAPI (1.9.200):
     - Logging (~> 1.1)
   - Logging (1.4.0)
-  - MatrixSDK (0.27.13):
-    - MatrixSDK/Core (= 0.27.13)
-  - MatrixSDK/Core (0.27.13):
+  - MatrixSDK (0.27.15):
+    - MatrixSDK/Core (= 0.27.15)
+  - MatrixSDK/Core (0.27.15):
     - AFNetworking (~> 4.0.0)
     - GZIP (~> 1.3.0)
     - libbase58 (~> 0.1.4)
     - MatrixSDKCrypto (= 0.4.3)
     - Realm (= 10.27.0)
     - SwiftyBeaver (= 1.9.5)
-  - MatrixSDK/JingleCallStack (0.27.13):
+  - MatrixSDK/JingleCallStack (0.27.15):
     - JitsiMeetSDKLite (= 8.1.2-lite)
     - MatrixSDK/Core
   - MatrixSDKCrypto (0.4.3)
@@ -179,7 +179,7 @@ SPEC CHECKSUMS:
   libPhoneNumber-iOS: 0a32a9525cf8744fe02c5206eb30d571e38f7d75
   LoggerAPI: ad9c4a6f1e32f518fdb43a1347ac14d765ab5e3d
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MatrixSDK: b5756a518af19296b94e3ad9b6f16648f9eb17c3
+  MatrixSDK: 12b379749b84ab5b3662042acb1914b9f9bb692b
   MatrixSDKCrypto: 27bee960e0e8b3a3039f3f3e93dd2ec88299c77e
   ReadMoreTextView: 19147adf93abce6d7271e14031a00303fe28720d
   Realm: 9ca328bd7e700cc19703799785e37f77d1a130f2
@@ -200,4 +200,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 484a1cdf04951cc82156f29de196efd76d3ad893
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.14.3

--- a/Riot/Assets/en.lproj/Localizable.strings
+++ b/Riot/Assets/en.lproj/Localizable.strings
@@ -182,6 +182,8 @@
 /* Group call from user, CallKit caller name */
 "GROUP_CALL_FROM_USER" = "%@ (Group call)";
 
+"UNSUPPORTED_CALL" = "Unsupported call";
+
 /** Key verification **/
 
 "KEY_VERIFICATION_REQUEST_FROM_USER" = "%@ wants to verify";

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -1253,6 +1253,7 @@ Tap the + to start adding people.";
 "call_no_stun_server_error_use_fallback_button" = "Try using %@";
 
 "call_actions_unhold" = "Resume";
+"call_unsupported_matrix_rtc_call" = "Unsupported call. The new Element X app is needed to join this call.";
 
 // No VoIP support
 "no_voip_title" = "Incoming call";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -1187,6 +1187,10 @@ public class VectorL10n: NSObject {
   public static var callTransferUsers: String { 
     return VectorL10n.tr("Vector", "call_transfer_users") 
   }
+  /// Unsupported call. The new Element X app is needed to join this call.
+  public static var callUnsupportedMatrixRtcCall: String { 
+    return VectorL10n.tr("Vector", "call_unsupported_matrix_rtc_call") 
+  }
   /// Video call with %@
   public static func callVideoWithUser(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "call_video_with_user", p1)

--- a/Riot/Modules/MatrixKit/Models/MXKAppSettings.m
+++ b/Riot/Modules/MatrixKit/Models/MXKAppSettings.m
@@ -169,6 +169,8 @@ static NSString *const kMXAppGroupID = @"group.org.matrix";
             kMXEventTypeStringCallHangup,
             kMXEventTypeStringCallReject,
             kMXEventTypeStringCallNegotiate,
+            kMXEventTypeStringCallNotify,
+            kMXEventTypeStringCallNotifyUnstable,
             kMXEventTypeStringSticker,
             kMXEventTypeStringKeyVerificationCancel,
             kMXEventTypeStringKeyVerificationDone,

--- a/Riot/Modules/Room/CellData/RoomBubbleCellData.h
+++ b/Riot/Modules/Room/CellData/RoomBubbleCellData.h
@@ -25,6 +25,7 @@ typedef NS_ENUM(NSInteger, RoomBubbleCellDataTag)
     RoomBubbleCellDataTagKeyVerificationConclusion,
     RoomBubbleCellDataTagCall,
     RoomBubbleCellDataTagGroupCall,
+    RoomBubbleCellDataTagRTCCallNotify,
     RoomBubbleCellDataTagRoomCreationIntro,
     RoomBubbleCellDataTagPoll,
     RoomBubbleCellDataTagLocation,

--- a/Riot/Modules/Room/CellData/RoomBubbleCellData.m
+++ b/Riot/Modules/Room/CellData/RoomBubbleCellData.m
@@ -142,6 +142,14 @@ NSString *const URLPreviewDidUpdateNotification = @"URLPreviewDidUpdateNotificat
                 self.displayTimestampForSelectedComponentOnLeftWhenPossible = NO;
                 break;
             }
+            case MXEventTypeCallNotify:
+            {
+                self.tag = RoomBubbleCellDataTagRTCCallNotify;
+                self.collapsable = NO;
+                self.collapsed = NO;
+                self.displayTimestampForSelectedComponentOnLeftWhenPossible = NO;
+                break;
+            }
             case MXEventTypePollStart:
             case MXEventTypePollEnd:
             {
@@ -374,6 +382,11 @@ NSString *const URLPreviewDidUpdateNotification = @"URLPreviewDidUpdateNotificat
             break;
         case RoomBubbleCellDataTagVoiceBroadcastNoDisplay:
             break;
+        case RoomBubbleCellDataTagRTCCallNotify:
+        {
+            hasNoDisplay = NO;
+            break;
+        }
         default:
             hasNoDisplay = [super hasNoDisplay];
             break;
@@ -1119,6 +1132,9 @@ NSString *const URLPreviewDidUpdateNotification = @"URLPreviewDidUpdateNotificat
         case RoomBubbleCellDataTagGroupCall:
             shouldAddEvent = NO;
             break;
+        case RoomBubbleCellDataTagRTCCallNotify:
+            shouldAddEvent = NO;
+            break;
         case RoomBubbleCellDataTagRoomCreateConfiguration:
             shouldAddEvent = NO;
             break;
@@ -1191,6 +1207,9 @@ NSString *const URLPreviewDidUpdateNotification = @"URLPreviewDidUpdateNotificat
             case MXEventTypeCallAnswer:
             case MXEventTypeCallHangup:
             case MXEventTypeCallReject:
+                shouldAddEvent = NO;
+                break;
+            case MXEventTypeCallNotify:
                 shouldAddEvent = NO;
                 break;
             case MXEventTypePollStart:

--- a/Riot/Modules/Room/RoomViewController.m
+++ b/Riot/Modules/Room/RoomViewController.m
@@ -3220,6 +3220,10 @@ static CGSize kThreadListBarButtonItemImageSize;
     {
         cellIdentifier = RoomTimelineCellIdentifierGroupCallStatus;
     }
+    else if (bubbleData.tag == RoomBubbleCellDataTagRTCCallNotify)
+    {
+        cellIdentifier = RoomTimelineCellIdentifierMatrixRTCCall;
+    }
     else if (bubbleData.attachment.type == MXKAttachmentTypeVoiceMessage || bubbleData.attachment.type == MXKAttachmentTypeAudio)
     {
         if (bubbleData.isIncoming)

--- a/Riot/Modules/Room/TimelineCells/Call/CallCellContentView.xib
+++ b/Riot/Modules/Room/TimelineCells/Call/CallCellContentView.xib
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iN0-l3-epB" customClass="CallCellContentView" customModule="Riot" customModuleProvider="target">
+        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iN0-l3-epB" customClass="CallCellContentView" customModule="Element" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="414" height="220"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="pdr-Jo-LHQ">
@@ -87,7 +87,7 @@
                                                         <constraint firstAttribute="height" constant="16" id="OdD-1h-kkV"/>
                                                     </constraints>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Active call" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A3h-4o-nXF">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Active call" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A3h-4o-nXF">
                                                     <rect key="frame" x="22" y="2" width="62" height="16"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                     <nil key="textColor"/>

--- a/Riot/Modules/Room/TimelineCells/Call/MatrixRTC/RoomMatrixRTCCallCell.swift
+++ b/Riot/Modules/Room/TimelineCells/Call/MatrixRTC/RoomMatrixRTCCallCell.swift
@@ -1,0 +1,29 @@
+// 
+// Copyright 2021-2024 New Vector Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only
+// Please see LICENSE in the repository root for full details.
+//
+
+import UIKit
+
+@objcMembers
+class RoomMatrixRTCCallCell: RoomCallBaseCell {
+    private static var className: String { String(describing: self) }
+    
+    //  MARK: - MXKCellRendering
+    
+    override func render(_ cellData: MXKCellData!) {
+        super.render(cellData)
+        
+        guard let bubbleCellData = cellData as? RoomBubbleCellData else { return }
+        let roomID = bubbleCellData.roomId
+        guard let room = bubbleCellData.mxSession.room(withRoomId: roomID) else { return }
+        
+        room.summary.setRoomAvatarImageIn(innerContentView.avatarImageView)
+        innerContentView.avatarImageView.defaultBackgroundColor = .clear
+        innerContentView.callerNameLabel.text = room.summary.displayName
+        statusText = VectorL10n.callUnsupportedMatrixRtcCall
+        bottomContentView = nil // Expands the size of the status stack.
+    }
+}

--- a/Riot/Modules/Room/TimelineCells/RoomTimelineCellIdentifier.h
+++ b/Riot/Modules/Room/TimelineCells/RoomTimelineCellIdentifier.h
@@ -128,6 +128,7 @@ typedef NS_ENUM(NSUInteger, RoomTimelineCellIdentifier) {
     // - Call
     RoomTimelineCellIdentifierDirectCallStatus,
     RoomTimelineCellIdentifierGroupCallStatus,
+    RoomTimelineCellIdentifierMatrixRTCCall,
     
     // - Voice message
     // -- Incoming

--- a/Riot/Modules/Room/TimelineCells/Styles/Plain/PlainRoomTimelineCellProvider.m
+++ b/Riot/Modules/Room/TimelineCells/Styles/Plain/PlainRoomTimelineCellProvider.m
@@ -235,6 +235,7 @@
 {
     [tableView registerClass:RoomDirectCallStatusCell.class forCellReuseIdentifier:RoomDirectCallStatusCell.defaultReuseIdentifier];
     [tableView registerClass:RoomGroupCallStatusCell.class forCellReuseIdentifier:RoomGroupCallStatusCell.defaultReuseIdentifier];
+    [tableView registerClass:RoomMatrixRTCCallCell.class forCellReuseIdentifier:RoomMatrixRTCCallCell.defaultReuseIdentifier];
 }
 
 - (void)registerVoiceMessageCellsForTableView:(UITableView*)tableView
@@ -520,6 +521,7 @@
     return @{
         @(RoomTimelineCellIdentifierDirectCallStatus) : RoomDirectCallStatusCell.class,
         @(RoomTimelineCellIdentifierGroupCallStatus) : RoomGroupCallStatusCell.class,
+        @(RoomTimelineCellIdentifierMatrixRTCCall) : RoomMatrixRTCCallCell.class,
     };
 }
 

--- a/RiotNSE/NotificationService.swift
+++ b/RiotNSE/NotificationService.swift
@@ -577,6 +577,15 @@ class NotificationService: UNNotificationServiceExtension {
                             notificationTitle = self.messageTitle(for: eventSenderName, in: roomDisplayName)
                             notificationBody = VectorL10n.pollTimelineEndedText
                         
+                        case .callNotify:
+                            if let callNotify = MXCallNotify(fromJSON: event.content) {
+                                let userIDs = callNotify.mentions.userIDs as? [String]
+                                if currentUserId.flatMap({ userIDs?.contains($0) }) ?? callNotify.mentions.room {
+                                    notificationTitle = self.messageTitle(for: eventSenderName, in: roomDisplayName)
+                                    notificationBody = NotificationService.localizedString(forKey: "UNSUPPORTED_CALL")
+                                }
+                            }
+                        
                         default:
                             break
                     }


### PR DESCRIPTION
This PR makes the following changes:

- Process `m.call.notify` events in the NSE (only when `m.mentions` includes you) showing an unsupported call notification.
- Show `m.call.notify` events in the timeline as unsupported calls.
- Update the SDK to include https://github.com/matrix-org/matrix-ios-sdk/pull/1887

Part of https://github.com/element-hq/element-ios/issues/7861

**EX on the left | EI on the right**

https://github.com/user-attachments/assets/66eadf1d-c9bd-4c62-bcde-4e587894cebe

