### PR TITLE
Allow project to compile with Xcode 16.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -35,7 +35,7 @@ abstract_target 'RiotPods' do
   pod 'KeychainAccess', '~> 4.2.2'
   pod 'WeakDictionary', '~> 2.0'
 
-  pod 'Sentry', '~> 7.15.0'
+  pod 'Sentry', '~> 8.40.1'
 
   pod 'zxcvbn-ios'
 

--- a/changelog.d/pr-7869.change
+++ b/changelog.d/pr-7869.change
@@ -1,0 +1,1 @@
+Allow project compile with Xcode 16.1


### PR DESCRIPTION
Project fails to compile with Xcode 16.1 due to Pod Sentry.

Update it from 7.15.0 to 8.40.1 seems to fix the problem.

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
