### PR TITLE
Fix a bug where Matrix RTC call notifications are removed immediately after display.

### DIFF
--- a/RiotNSE/NotificationService.swift
+++ b/RiotNSE/NotificationService.swift
@@ -795,7 +795,7 @@ class NotificationService: UNNotificationServiceExtension {
             return Constants.callInviteNotificationCategoryIdentifier
         }
         
-        guard event.eventType == .roomMessage || event.eventType == .roomEncrypted else {
+        guard event.eventType == .roomMessage || event.eventType == .roomEncrypted || event.eventType == .callNotify else {
             return Constants.toBeRemovedNotificationCategoryIdentifier
         }
         


### PR DESCRIPTION
The `m.call.notify` notification was getting marked as "to be removed", and then immediately followed up by an `m.call.member` event which, whilst it is ignored as a notification, still triggers [the removal](https://github.com/element-hq/element-ios/blob/34ddefaac01f49e01ee8e69d31db4378c1ae1e13/RiotNSE/NotificationService.swift#L104) before being handled.