### PR TITLE
Fix a bug where UIA for cross signing wasn't needed until after checking for it.

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -39,16 +39,16 @@ PODS:
   - LoggerAPI (1.9.200):
     - Logging (~> 1.1)
   - Logging (1.4.0)
-  - MatrixSDK (0.27.15):
-    - MatrixSDK/Core (= 0.27.15)
-  - MatrixSDK/Core (0.27.15):
+  - MatrixSDK (0.27.16):
+    - MatrixSDK/Core (= 0.27.16)
+  - MatrixSDK/Core (0.27.16):
     - AFNetworking (~> 4.0.0)
     - GZIP (~> 1.3.0)
     - libbase58 (~> 0.1.4)
     - MatrixSDKCrypto (= 0.4.3)
     - Realm (= 10.27.0)
     - SwiftyBeaver (= 1.9.5)
-  - MatrixSDK/JingleCallStack (0.27.15):
+  - MatrixSDK/JingleCallStack (0.27.16):
     - JitsiMeetSDKLite (= 8.1.2-lite)
     - MatrixSDK/Core
   - MatrixSDKCrypto (0.4.3)
@@ -179,7 +179,7 @@ SPEC CHECKSUMS:
   libPhoneNumber-iOS: 0a32a9525cf8744fe02c5206eb30d571e38f7d75
   LoggerAPI: ad9c4a6f1e32f518fdb43a1347ac14d765ab5e3d
   Logging: beeb016c9c80cf77042d62e83495816847ef108b
-  MatrixSDK: 12b379749b84ab5b3662042acb1914b9f9bb692b
+  MatrixSDK: ce8f2cec670c2212144a129cc617d4144c89b97f
   MatrixSDKCrypto: 27bee960e0e8b3a3039f3f3e93dd2ec88299c77e
   ReadMoreTextView: 19147adf93abce6d7271e14031a00303fe28720d
   Realm: 9ca328bd7e700cc19703799785e37f77d1a130f2
@@ -198,6 +198,6 @@ SPEC CHECKSUMS:
   zxcvbn-ios: fef98b7c80f1512ff0eec47ac1fa399fc00f7e3c
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: 484a1cdf04951cc82156f29de196efd76d3ad893
+PODFILE CHECKSUM: 9148246fffa2c32e3c9b29a51cae4bb037497056
 
 COCOAPODS: 1.14.3

--- a/Riot/Modules/CrossSigning/Setup/CrossSigningSetupCoordinator.swift
+++ b/Riot/Modules/CrossSigning/Setup/CrossSigningSetupCoordinator.swift
@@ -53,22 +53,6 @@ final class CrossSigningSetupCoordinator: CrossSigningSetupCoordinatorType {
     }
     
     // MARK: - Private methods
-
-    private func showReauthentication(authenticationSession: MXAuthenticationSession) {
-        let setupCrossSigningRequest = self.crossSigningService.setupCrossSigningRequest()
-        
-        let reauthenticationParameters = ReauthenticationCoordinatorParameters(session: parameters.session,
-                                                                               presenter: parameters.presenter,
-                                                                               title: parameters.title,
-                                                                               message: parameters.message,
-                                                                               authenticationSession: authenticationSession)
-        
-        let coordinator = ReauthenticationCoordinator(parameters: reauthenticationParameters)
-        coordinator.delegate = self
-        self.add(childCoordinator: coordinator)
-        
-        coordinator.start()
-    }
     
     private func setupCrossSigning(with authenticationParameters: [String: Any] = [:]) {
         guard let crossSigning = parameters.session.crypto?.crossSigning else { return }
@@ -86,6 +70,22 @@ final class CrossSigningSetupCoordinator: CrossSigningSetupCoordinatorType {
                 delegate?.crossSigningSetupCoordinator(self, didFailWithError: error)
             }
         }
+    }
+
+    private func showReauthentication(authenticationSession: MXAuthenticationSession) {
+        let setupCrossSigningRequest = self.crossSigningService.setupCrossSigningRequest()
+        
+        let reauthenticationParameters = ReauthenticationCoordinatorParameters(session: parameters.session,
+                                                                               presenter: parameters.presenter,
+                                                                               title: parameters.title,
+                                                                               message: parameters.message,
+                                                                               authenticationSession: authenticationSession)
+        
+        let coordinator = ReauthenticationCoordinator(parameters: reauthenticationParameters)
+        coordinator.delegate = self
+        self.add(childCoordinator: coordinator)
+        
+        coordinator.start()
     }
 }
 


### PR DESCRIPTION
The check didn't include the parameters that are used for the reset, and as mentioned in [the spec](https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3keysdevice_signingupload), from v1.11 the use of UIA depends on the change being made.

The fix is to simply attempt to reset, and then handle the UIA failure manually after this if it occurs (retrying when the user has completed the authentication).

Unrelated: I updated the SDK so that we pull in https://github.com/matrix-org/matrix-ios-sdk/pull/1885 ready for the next release.

Fixes https://github.com/element-hq/element-ios/issues/7838