### PR TITLE
Fix display of incoming call for group calls when receiving VOIP noti…

### DIFF
--- a/Riot/Managers/Call/CallPresenter.swift
+++ b/Riot/Managers/Call/CallPresenter.swift
@@ -309,8 +309,12 @@ class CallPresenter: NSObject {
                     return
                 }
                 let user = session.user(withUserId: event.sender)
-                let displayName = NSString.localizedUserNotificationString(forKey: "GROUP_CALL_FROM_USER",
-                                                                           arguments: [user?.displayname as Any])
+                let displayNameUNLocalizedString = NSString.localizedUserNotificationString(forKey: "GROUP_CALL_FROM_USER",
+                                                                                            arguments: [user?.displayname as Any])
+
+                // will fix app crash when CXCallUpdate accesses the localizedCallerName property because list of allowed classes for com.apple.callkit.callsourcehost service contains only NSString
+                let displayNameNSString = NSString(string: displayNameUNLocalizedString)
+                let displayName = String(displayNameNSString)
                 
                 MXLog.debug("[CallPresenter] processWidgetEvent: Report new incoming call with id: \(newUUID.uuidString)")
                 

--- a/Riot/Managers/Call/CallPresenter.swift
+++ b/Riot/Managers/Call/CallPresenter.swift
@@ -313,8 +313,7 @@ class CallPresenter: NSObject {
                                                                                             arguments: [user?.displayname as Any])
 
                 // will fix app crash when CXCallUpdate accesses the localizedCallerName property because list of allowed classes for com.apple.callkit.callsourcehost service contains only NSString
-                let displayNameNSString = NSString(string: displayNameUNLocalizedString)
-                let displayName = String(displayNameNSString)
+                let displayName = NSString(string: displayNameUNLocalizedString) as String
                 
                 MXLog.debug("[CallPresenter] processWidgetEvent: Report new incoming call with id: \(newUUID.uuidString)")
                 

--- a/changelog.d/7858.bugfix
+++ b/changelog.d/7858.bugfix
@@ -1,0 +1,1 @@
+Fix display of incoming call for group calls when receiving VOIP notification.


### PR DESCRIPTION
…fication

**Problem**: When making a group call and the "Ring for group calls" option is enabled, the incoming call is not displayed (CallKit functionality)

**Reason**: The name for the incoming call is generated via the localizedUserNotificationStringForKey method of the NSString extension, but the result of the method is an instance of the UNLocalizedString class, which is not allowed for the CallKit subsystem. This is reported by the operating system log:
```
Attempted to decode a collection type 'UNLocalizedString' (subclass of 'NSString') for key 'localizedCallerName'. 'UNLocalizedString' requires its subclasses to be explicitly added to the allowed classes list but it is not present. Allowing this has been a source of security issues. Please ensure you meant this type to be in archives: 'UNLocalizedString' (0x1fc31f888) [/System/Library/Frameworks/UserNotifications.framework]
NSXPCInterface: <NSXPCInterface: 0xbdad37900>
Protocol: CXProviderVendorProtocol
SEL: commitTransaction: (1 arguments, 0 proxies)
 Classes: [{NSNumber, NSURL, NSError, CXCallUpdate, NSDate, NSDictionary, NSString, NSSet, CXTransaction, CXAction, NSArray, NSOrderedSet, NSUUID, NSData, NSMutableSet, NSMutableOrderedSet, NSMutableArray, NSMutableDictionary}]
 Reply block: (arg #-1, (0 arguments, 0 proxies), signature '(null)') []

<NSXPCConnection: 0xbdad3c820> connection from pid 592 on mach service named com.apple.callkit.callsourcehost
```

and also the following error:
```
<NSXPCConnection: 0xbdad3c820> connection from pid 592 on mach service named com.apple.callkit.callsourcehost: Exception caught during decoding of received selector reportNewIncomingCallWithUUID:update:reply:, dropping incoming message.
Exception: Exception while decoding argument 1 (#3 of invocation):
Exception: value for key 'localizedCallerName' was of unexpected class 'UNLocalizedString' (0x1fc31f888) [/System/Library/Frameworks/UserNotifications.framework].
Allowed classes are:
 {(
 "'NSString' (0x1fc2886c8) [/System/Library/Frameworks/Foundation.framework]"
)}
(
 0 CoreFoundation 0x000000019b57cf2c 00E76A98-210C-3CB5-930B-F236807FF24C + 540460
 1 libobjc.A.dylib 0x0000000193432018 objc_exception_throw + 60
 2 Foundation 0x000000019a3aeba0 3D3A12E3-F5E9-361F-B00A-4A5E8861AA55 + 39840
 3 Foundation 0x000000019a3ae6a8 3D3A12E3-F5E9-361F-B00A-4A5E8861AA55 + 38568
 4 Foundation 0x000000019a3ae068 3D3A12E3-F5E9-361F-B00A-4A5E8861AA55 + 36968
 5 Foundation 0x000000019a3ad164 3D3A12E3-F5E9-361F-B00A-4A5E8861AA55 + 33124
 6 CallKit 0x00000001bcf6e300 F71F082D-30F3-3293-BCC2-B86903390905 + 230144
 7 Foundation 0x000000019a3ae6e8 3D3A12E3-F5E9-361F-B00A-4A5E8861AA55 + 38632
 8 Foundation 0x000000019a3ad030 3D3A12E3-F5E9-361F-B00A-4A5E8861AA55 + 32816
 9 Foundation 0x000000019a40b750 3D3A12E3-F5E9-361F-B00A-4A5E8861AA55 + 419664
 10 Foundation 0x000000019a408800 3D3A12E3-F5E9-361F-B00A-4A5E8861AA55 + 407552
 11 Foundation 0x000000019a460fe4 3D3A12E3-F5E9-361F-B00A-4A5E8861AA55 + 770020
 12 Foundation 0x000000019a45fd50 3D3A12E3-F5E9-361F-B00A-4A5E8861AA55 + 765264
 13 Foundation 0x000000019a45f4b4 3D3A12E3-F5E9-361F-B00A-4A5E8861AA55 + 763060
 14 Foundation 0x000000019a45f36c 3D3A12E3-F5E9-361F-B00A-4A5E8861AA55 + 762732
 15 libxpc.dylib 0x00000001f8424cbc 3614A74F-EDA2-3843-8092-CEDB505020F0 + 72892
 16 libxpc.dylib 0x00000001f8426908 3614A74F-EDA2-3843-8092-CEDB505020F0 + 80136
 17 libdispatch.dylib 0x00000001a3421e94 81D355DF-266A-3010-BAB8-113B76A206C1 + 16020
 18 libdispatch.dylib 0x00000001a343e000 81D355DF-266A-3010-BAB8-113B76A206C1 + 131072
 19 libdispatch.dylib 0x00000001a3429284 81D355DF-266A-3010-BAB8-113B76A206C1 + 45700
 20 libdispatch.dylib 0x00000001a343ed50 81D355DF-266A-3010-BAB8-113B76A206C1 + 134480
 21 libdispatch.dylib 0x00000001a3429284 81D355DF-266A-3010-BAB8-113B76A206C1 + 45700
 22 libdispatch.dylib 0x00000001a3429f64 81D355DF-266A-3010-BAB8-113B76A206C1 + 48996
 23 libdispatch.dylib 0x00000001a3434cb4 81D355DF-266A-3010-BAB8-113B76A206C1 + 93364
24 libdispatch.dylib 0x00000001a3434528 81D355DF-266A-3010-BAB8-113B76A206C1 + 91432
```
and 6 seconds after these errors the system stops the application with the following reason:
```
Killing VoIP app <private> because it failed to post an incoming call in time.
```

**Solution**: explicitly cast the result of localizedUserNotificationStringForKey to NSString

### Pull Request Checklist

- [X] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [X] Pull request is based on the develop branch
- [X] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [X] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [X] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

Signed-off-by: <hek4ek@gmail.com>

Fixes #7858