### PR TITLE
Update the SDK.

### DIFF
--- a/changelog.d/pr-7883.bugfix
+++ b/changelog.d/pr-7883.bugfix
@@ -1,0 +1,1 @@
+Fix a crash when restoring from a backup and a bug where you couldn't reset cross-signing.  


### PR DESCRIPTION
Includes a fix for a crash and for resetting cross signing.