### PR TITLE
Update RTE

### DIFF
--- a/Riot.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Riot.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "7aef13d4107c517de08082c578f4e05c70046de1a77e79990a0ba3eef4abdf25",
   "pins" : [
     {
       "identity" : "devicekit",
@@ -48,10 +49,10 @@
     {
       "identity" : "matrix-rich-text-editor-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/matrix-org/matrix-rich-text-editor-swift",
+      "location" : "https://github.com/element-hq/matrix-rich-text-editor-swift",
       "state" : {
-        "revision" : "21c0dd6e9c0b38d19d97af8e3e99fe01df56825d",
-        "version" : "2.37.3"
+        "revision" : "b6583a47b5d14d2dc8405a0303ebd4041b877707",
+        "version" : "2.37.12"
       }
     },
     {
@@ -100,5 +101,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/RiotSwiftUI/Modules/Room/CompletionSuggestion/Service/CompletionSuggestionService.swift
+++ b/RiotSwiftUI/Modules/Room/CompletionSuggestion/Service/CompletionSuggestionService.swift
@@ -120,6 +120,8 @@ class CompletionSuggestionService: CompletionSuggestionServiceProtocol {
             currentTextTriggerSubject.send(nil)
         case .slash:
             currentTextTriggerSubject.send(TextTrigger(key: .slash, text: suggestionPattern.text))
+        case .custom:
+            break
         }
     }
     

--- a/project.yml
+++ b/project.yml
@@ -58,8 +58,8 @@ packages:
     url: https://github.com/element-hq/swift-ogg
     branch: 0.0.1
   WysiwygComposer:
-    url: https://github.com/matrix-org/matrix-rich-text-editor-swift
-    version: 2.37.3
+    url: https://github.com/element-hq/matrix-rich-text-editor-swift
+    exactVersion: 2.37.12
   DeviceKit:
     url: https://github.com/devicekit/DeviceKit
     majorVersion: 4.7.0


### PR DESCRIPTION
This update is required with Xcode 16 to release a newer version of the app, due to an issue with the previous version, which included a stub framework where the min iOS target mismatched the one of the package.