### PR TITLE
Support for experimental MSC4286 to not render external payment details

### DIFF
--- a/Riot/Modules/MatrixKit/Categories/DTHTMLElement+MatrixKit.swift
+++ b/Riot/Modules/MatrixKit/Categories/DTHTMLElement+MatrixKit.swift
@@ -23,6 +23,16 @@ public extension DTHTMLElement {
             // Remove any attachments to fix rendering.
             textAttachment = nil
             
+            // Handle special case for span with data-mx-external-payment-details
+            // This could be based on Storefront.current.countryCode to show the link
+            // content in unrestricted countries. e.g. currently USA
+            if name == "span",
+               let attributes = attributes as? [String: String],
+               attributes["data-msc4286-external-payment-details"] != nil {
+                parent.removeChildNode(self)
+                return
+            }
+            
             // If the element has plain text content show that,
             // otherwise prevent the tag from displaying.
             if let stringContent = attributedString()?.string,

--- a/RiotTests/MatrixKitTests/MXKEventFormatterTests.m
+++ b/RiotTests/MatrixKitTests/MXKEventFormatterTests.m
@@ -239,6 +239,24 @@ Please see LICENSE in the repository root for full details.
     XCTAssertFalse(hasAttachment, @"iFrame attachments should be removed as they're not included in the allowedHTMLTags array.");
 }
 
+- (void)testMxExternalPaymentDetailsRemoved
+{
+    // Given an HTML string containing a <span> with data-mx-external-payment-details.
+    NSString *html = @"This is visible<span data-msc4286-external-payment-details>. But text is hidden <a href=\"https://matrix.org\">and this link too</a></span>";
+    
+    // When rendering this string as an attributed string.
+    NSAttributedString *attributedString = [eventFormatter renderHTMLString:html
+                                                                   forEvent:anEvent
+                                                              withRoomState:nil
+                                                         andLatestRoomState:nil];
+
+    // Then the attributed string should have the <span> stripped and not include any attachments.
+    XCTAssertEqualObjects(attributedString.string, @"This is visible", @"The <span data-msc4286-external-payment-details> tag content should be removed.");
+
+    BOOL hasAttachment = [attributedString containsAttachmentsInRange:NSMakeRange(0, attributedString.length)];
+    XCTAssertFalse(hasAttachment, @"span attachments should be removed as they're not included in the allowedHTMLTags array.");
+}
+
 - (void)testRenderHTMLStringWithMXReply
 {
     // Given an HTML string representing a matrix reply.

--- a/changelog.d/pr-7927.change
+++ b/changelog.d/pr-7927.change
@@ -1,0 +1,1 @@
+Support for experimental MSC4286 during event rendering.


### PR DESCRIPTION
Ref: https://github.com/matrix-org/matrix-spec-proposals/pull/4286

| Before | After |
|-|-|
|![Simulator Screenshot - iPhone 16 Pro - 2025-05-26 at 17 38 09](https://github.com/user-attachments/assets/e6d7fa24-aeb3-4d7b-8688-b9e35e5059b5)|![Simulator Screenshot - iPhone 16 Pro - 2025-05-26 at 17 35 46](https://github.com/user-attachments/assets/4e8667ba-9214-41eb-97ad-639a4159636f)|

In the above example the `formatted_body` of the event looks like this:

`Thanks for subscribing!<span data-msc4286-external-payment-details> You can manage your subscription and view your payment history <a href="https://account.example.com/account/plan">here</a> at any time</span>`

### Pull Request Checklist

- [x] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md)
- [x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ ] Accessibility has been taken into account.
* [x] Pull request is based on the develop branch
- [x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [x] You've made a self review of your PR
- [x] Pull request includes screenshots or videos of UI changes
- [x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)
