### PR TITLE
Replace confused emoji with slightly frowning face in quick reactions

### DIFF
--- a/Riot/Modules/Room/ContextualMenu/ReactionsMenu/ReactionsMenuViewModel.swift
+++ b/Riot/Modules/Room/ContextualMenu/ReactionsMenu/ReactionsMenuViewModel.swift
@@ -11,7 +11,7 @@ import Foundation
     
     // MARK: - Properties
     
-    private let reactions = ["👍", "👎", "😄", "🎉", "😕", "❤️", "🚀", "👀"]
+    private let reactions = ["👍", "👎", "😄", "🎉", "🙁", "❤️", "🚀", "👀"]
     private var currentViewDatas: [ReactionMenuItemViewData] = []
     
     // MARK: Private

--- a/changelog.d/pr-7960.change
+++ b/changelog.d/pr-7960.change
@@ -1,0 +1,1 @@
+Replace confused emoji with slightly frowning face in quick reactions menu for better emotional expression.


### PR DESCRIPTION
Replace 😕 (confused face) with 🙁 (slightly frowning face) in the quick reaction menu to better represent mild disappointment rather than confusion about the message content.  At a glance they look similar, but when hovering over the reaction in Element Desktop, it can send the wrong message.

### Pull Request Checklist

- [X ] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md)
- [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ X] Accessibility has been taken into account.
* [ X] Pull request is based on the develop branch
- [ X] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ X] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [ X] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)