### PR TITLE
When keyboard appears, the InputToolbarview hides the background in minimized mode.

### DIFF
--- a/Riot/Modules/Room/Views/WYSIWYGInputToolbar/WysiwygInputToolbarView.swift
+++ b/Riot/Modules/Room/Views/WYSIWYGInputToolbar/WysiwygInputToolbarView.swift
@@ -285,6 +285,7 @@ class WysiwygInputToolbarView: MXKRoomInputToolbarView, NibLoadable, HtmlRoomInp
         cancellables = [
             hostingViewController.heightPublisher
                 .removeDuplicates()
+                .debounce(for: .milliseconds(150), scheduler: RunLoop.main)
                 .sink(receiveValue: { [weak self] idealHeight in
                     guard let self = self else { return }
                     self.updateToolbarHeight(wysiwygHeight: idealHeight)

--- a/changelog.d/ElementIOS7970.bugfix
+++ b/changelog.d/ElementIOS7970.bugfix
@@ -1,0 +1,1 @@
+WysiwygInputToolbarView: Fixes the toolbarview hiding the chat room 75% when typing text in minimsed mode. This happens from iOS26!. Contributed by Shunmugaraj Subramanian.


### PR DESCRIPTION
Added debounce for the height update to fix #7970.
The issue happened with iOS 26.

### Pull Request Checklist

- [ x] I read the [contributing guide](https://github.com/element-hq/element-ios/blob/develop/CONTRIBUTING.md)
- [ x] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
- [ x] Accessibility has been taken into account.
* [ x] Pull request is based on the develop branch
- [ x] Pull request contains a [changelog file](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#changelog) in ./changelog.d
- [ x] You've made a self review of your PR
- [ ] Pull request includes screenshots or videos of UI changes
- [ x] Pull request includes a [sign off](https://github.com/matrix-org/matrix-ios-sdk/blob/develop/CONTRIBUTING.md#sign-off)

<img width="414" height="896" alt="Hideing" src="https://github.com/user-attachments/assets/8a5338e1-f863-46c5-b454-2f804afe2027" />


 Signed-off-by: Shunmugaraj Subramanian <shunmugaraj.subramanian@gmail.com>