### PR TITLE
Display a migration banner after a date or if is activated by the wellknown

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,2 @@
 brew "mint"
-brew "getsentry/tools/sentry-cli"
+cask "sentry-cli"

--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -468,7 +468,6 @@ final class BuildSettings: NSObject {
     /// The date from which the migration banner is displayed when the homeserver Well Known has no
     /// `io.element.migration_banner` section. Before this date, a missing section hides the banner.
     /// When the section is present, its `enabled` value is always used instead.
-    /// Note: this date must be kept in sync with Element Android.
     static let migrationBannerShowWhenNotConfiguredStartDate = DateComponents(calendar: Calendar(identifier: .gregorian),
                                                                               timeZone: TimeZone(secondsFromGMT: 0),
                                                                               year: 2026,

--- a/Config/BuildSettings.swift
+++ b/Config/BuildSettings.swift
@@ -463,6 +463,18 @@ final class BuildSettings: NSObject {
     /// are ready to migrate your users.
     static let replacementApp: ReplacementApp? = .init()
     
+    // MARK: - Migration Banner
+    
+    /// The date from which the migration banner is displayed when the homeserver Well Known has no
+    /// `io.element.migration_banner` section. Before this date, a missing section hides the banner.
+    /// When the section is present, its `enabled` value is always used instead.
+    /// Note: this date must be kept in sync with Element Android.
+    static let migrationBannerShowWhenNotConfiguredStartDate = DateComponents(calendar: Calendar(identifier: .gregorian),
+                                                                              timeZone: TimeZone(secondsFromGMT: 0),
+                                                                              year: 2026,
+                                                                              month: 11,
+                                                                              day: 15).date!
+    
     // MARK: - Verification Required Banner
     
     static let verificationRequiredBannerLearnMoreURL = URL(string: "https://docs.element.io/latest/element-support/device-verification/how-to-verify-devices")!

--- a/Riot/Assets/en.lproj/Vector.strings
+++ b/Riot/Assets/en.lproj/Vector.strings
@@ -106,6 +106,11 @@
 "sunset_download_banner_message" = "Faster, more secure, and packed with powerful collaboration tools.";
 "sunset_download_banner_learn_more" = "Learn more";
 
+// MARK: Migration banner
+"migration_banner_title" = "Download Element X";
+"migration_banner_body" = "Faster sync, a cleaner design, and new features you won't find here. The Element Classic app will be retired soon, so now's the time to make the move.";
+"migration_banner_download_button" = "Download app";
+
 // MARK: Onboarding
 "onboarding_splash_register_button_title" = "Create account";
 "onboarding_splash_login_button_title" = "I already have an account";

--- a/Riot/Generated/Strings.swift
+++ b/Riot/Generated/Strings.swift
@@ -3803,6 +3803,18 @@ public class VectorL10n: NSObject {
   public static func microphoneAccessNotGrantedForVoiceMessage(_ p1: String) -> String {
     return VectorL10n.tr("Vector", "microphone_access_not_granted_for_voice_message", p1)
   }
+  /// Faster sync, a cleaner design, and new features you won't find here. The Element Classic app will be retired soon, so now's the time to make the move.
+  public static var migrationBannerBody: String { 
+    return VectorL10n.tr("Vector", "migration_banner_body") 
+  }
+  /// Download app
+  public static var migrationBannerDownloadButton: String { 
+    return VectorL10n.tr("Vector", "migration_banner_download_button") 
+  }
+  /// Download Element X
+  public static var migrationBannerTitle: String { 
+    return VectorL10n.tr("Vector", "migration_banner_title") 
+  }
   /// More
   public static var more: String { 
     return VectorL10n.tr("Vector", "more") 

--- a/Riot/Model/HomeserverConfiguration/HomeserverConfiguration.swift
+++ b/Riot/Model/HomeserverConfiguration/HomeserverConfiguration.swift
@@ -15,12 +15,15 @@ final class HomeserverConfiguration: NSObject {
     let jitsi: HomeserverJitsiConfiguration
     let encryption: HomeserverEncryptionConfiguration
     let tileServer: HomeserverTileServerConfiguration
+    let migrationBanner: HomeserverMigrationBannerConfiguration
     
     init(jitsi: HomeserverJitsiConfiguration,
          encryption: HomeserverEncryptionConfiguration,
-         tileServer: HomeserverTileServerConfiguration) {
+         tileServer: HomeserverTileServerConfiguration,
+         migrationBanner: HomeserverMigrationBannerConfiguration) {
         self.jitsi = jitsi
         self.encryption = encryption
         self.tileServer = tileServer
+        self.migrationBanner = migrationBanner
     }
 }

--- a/Riot/Model/HomeserverConfiguration/HomeserverConfigurationBuilder.swift
+++ b/Riot/Model/HomeserverConfiguration/HomeserverConfigurationBuilder.swift
@@ -14,6 +14,20 @@ final class HomeserverConfigurationBuilder: NSObject {
     // MARK: - Properties
     
     private let vectorWellKnownParser = VectorWellKnownParser()
+    private let currentDateProvider: () -> Date
+    
+    // MARK: - Setup
+    
+    override convenience init() {
+        self.init(currentDateProvider: Date.init)
+    }
+    
+    /// - Parameter currentDateProvider: Provides the current date, used for time based configuration. Injectable for tests.
+    init(currentDateProvider: @escaping () -> Date) {
+        self.currentDateProvider = currentDateProvider
+        
+        super.init()
+    }
     
     // MARK: - Public
     
@@ -21,10 +35,12 @@ final class HomeserverConfigurationBuilder: NSObject {
     func build(from wellKnown: MXWellKnown?) -> HomeserverConfiguration {
         var vectorWellKnownEncryptionConfiguration: VectorWellKnownEncryptionConfiguration?
         var vectorWellKnownJitsiConfiguration: VectorWellKnownJitsiConfiguration?
+        var vectorWellKnownMigrationBannerConfiguration: VectorWellKnownMigrationBannerConfiguration?
         
         if let wellKnown = wellKnown, let vectorWellKnown = self.vectorWellKnownParser.parse(jsonDictionary: wellKnown.jsonDictionary()) {
             vectorWellKnownEncryptionConfiguration = self.getEncryptionConfiguration(from: vectorWellKnown)
             vectorWellKnownJitsiConfiguration = self.getJitsiConfiguration(from: vectorWellKnown)
+            vectorWellKnownMigrationBannerConfiguration = vectorWellKnown.migrationBanner
         }
 
         // Encryption configuration
@@ -77,6 +93,10 @@ final class HomeserverConfigurationBuilder: NSObject {
         
         let tileServerConfiguration = HomeserverTileServerConfiguration(mapStyleURL: tileServerMapStyleURL)
         
+        // Migration banner configuration
+        
+        let migrationBannerConfiguration = self.getMigrationBannerConfiguration(from: vectorWellKnownMigrationBannerConfiguration)
+        
         // Create HomeserverConfiguration
         
         let jitsiConfiguration = HomeserverJitsiConfiguration(serverDomain: jitsiPreferredDomain,
@@ -85,7 +105,8 @@ final class HomeserverConfigurationBuilder: NSObject {
                 
         return HomeserverConfiguration(jitsi: jitsiConfiguration,
                                        encryption: encryptionConfiguration,
-                                       tileServer: tileServerConfiguration)
+                                       tileServer: tileServerConfiguration,
+                                       migrationBanner: migrationBannerConfiguration)
     }
     
     // MARK: - Private
@@ -122,6 +143,23 @@ final class HomeserverConfigurationBuilder: NSObject {
         }
         
         return encryptionConfiguration
+    }
+    
+    /// Resolve the migration banner configuration.
+    ///
+    /// - When the `io.element.migration_banner` section is present, the banner follows its `enabled` value (enabled when not provided).
+    /// - When the section is missing (or the Well Known could not be parsed), the banner is hidden until
+    /// `BuildSettings.migrationBannerShowWhenNotConfiguredStartDate` and shown from this date on.
+    private func getMigrationBannerConfiguration(from vectorWellKnownConfiguration: VectorWellKnownMigrationBannerConfiguration?) -> HomeserverMigrationBannerConfiguration {
+        let isEnabled: Bool
+        if let vectorWellKnownConfiguration = vectorWellKnownConfiguration {
+            isEnabled = vectorWellKnownConfiguration.isEnabled ?? true
+        } else {
+            isEnabled = currentDateProvider() >= BuildSettings.migrationBannerShowWhenNotConfiguredStartDate
+            MXLog.debug("[HomeserverConfigurationBuilder] getMigrationBannerConfiguration - No configuration found, enabled: \(isEnabled)")
+        }
+        
+        return HomeserverMigrationBannerConfiguration(isEnabled: isEnabled)
     }
     
     private func jitsiServerURL(from jitsiServerDomain: String) -> URL? {

--- a/Riot/Model/HomeserverConfiguration/HomeserverMigrationBannerConfiguration.swift
+++ b/Riot/Model/HomeserverConfiguration/HomeserverMigrationBannerConfiguration.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// `HomeserverMigrationBannerConfiguration` gives the resolved configuration of the banner inviting users
-/// to migrate to Element X, based on the `io.element.migration_banner` Well Known section and the default values.
+/// to migrate to the new app, based on the `io.element.migration_banner` Well Known section and the default values.
 @objcMembers
 final class HomeserverMigrationBannerConfiguration: NSObject {
     /// Indicate if the banner is enabled for this homeserver.

--- a/Riot/Model/HomeserverConfiguration/HomeserverMigrationBannerConfiguration.swift
+++ b/Riot/Model/HomeserverConfiguration/HomeserverMigrationBannerConfiguration.swift
@@ -1,0 +1,23 @@
+// 
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+
+/// `HomeserverMigrationBannerConfiguration` gives the resolved configuration of the banner inviting users
+/// to migrate to Element X, based on the `io.element.migration_banner` Well Known section and the default values.
+@objcMembers
+final class HomeserverMigrationBannerConfiguration: NSObject {
+    /// Indicate if the banner is enabled for this homeserver.
+    /// Note: this doesn't take into account a potential dismissal of the banner by the user.
+    let isEnabled: Bool
+    
+    init(isEnabled: Bool) {
+        self.isEnabled = isEnabled
+        
+        super.init()
+    }
+}

--- a/Riot/Model/WellKnown/VectorWellKnown.swift
+++ b/Riot/Model/WellKnown/VectorWellKnown.swift
@@ -13,6 +13,7 @@ import Foundation
 struct VectorWellKnown {
     let encryption: VectorWellKnownEncryptionConfiguration?
     let jitsi: VectorWellKnownJitsiConfiguration?
+    let migrationBanner: VectorWellKnownMigrationBannerConfiguration?
     
     // Deprecated properties
     let deprecatedEncryption: VectorWellKnownEncryptionConfiguration?
@@ -25,9 +26,20 @@ extension VectorWellKnown: Decodable {
     enum CodingKeys: String, CodingKey {
         case encryption = "io.element.e2ee"
         case jitsi = "io.element.jitsi"
+        case migrationBanner = "io.element.migration_banner"
         // Deprecated keys
         case deprecatedEncryption = "im.vector.riot.e2ee"
         case deprecatedJitsi = "im.vector.riot.jitsi"
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        encryption = try container.decodeIfPresent(VectorWellKnownEncryptionConfiguration.self, forKey: .encryption)
+        jitsi = try container.decodeIfPresent(VectorWellKnownJitsiConfiguration.self, forKey: .jitsi)
+        deprecatedEncryption = try container.decodeIfPresent(VectorWellKnownEncryptionConfiguration.self, forKey: .deprecatedEncryption)
+        deprecatedJitsi = try container.decodeIfPresent(VectorWellKnownJitsiConfiguration.self, forKey: .deprecatedJitsi)
+        // A malformed migration banner section (e.g. not a JSON object) must not prevent the other sections from being parsed.
+        migrationBanner = try? container.decodeIfPresent(VectorWellKnownMigrationBannerConfiguration.self, forKey: .migrationBanner)
     }
 }
 
@@ -69,4 +81,20 @@ struct VectorWellKnownJitsiConfiguration: Decodable {
     let preferredDomain: String?
     /// Override native calling with Jitsi for 1:1 calls.
     let useFor1To1Calls: Bool?
+}
+
+// MARK: - Migration Banner
+
+/// Raw content of the `io.element.migration_banner` Well Known section, used to configure the banner
+/// inviting users to migrate to Element X.
+///
+/// The resolution of the default values is done by `HomeserverConfigurationBuilder`.
+struct VectorWellKnownMigrationBannerConfiguration: Decodable {
+    /// Indicate if the banner should be displayed. `nil` when not provided (defaults to enabled).
+    let isEnabled: Bool?
+    
+    /// JSON keys associated to `VectorWellKnownMigrationBannerConfiguration`
+    enum CodingKeys: String, CodingKey {
+        case isEnabled = "enabled"
+    }
 }

--- a/Riot/Model/WellKnown/VectorWellKnown.swift
+++ b/Riot/Model/WellKnown/VectorWellKnown.swift
@@ -31,16 +31,6 @@ extension VectorWellKnown: Decodable {
         case deprecatedEncryption = "im.vector.riot.e2ee"
         case deprecatedJitsi = "im.vector.riot.jitsi"
     }
-    
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        encryption = try container.decodeIfPresent(VectorWellKnownEncryptionConfiguration.self, forKey: .encryption)
-        jitsi = try container.decodeIfPresent(VectorWellKnownJitsiConfiguration.self, forKey: .jitsi)
-        deprecatedEncryption = try container.decodeIfPresent(VectorWellKnownEncryptionConfiguration.self, forKey: .deprecatedEncryption)
-        deprecatedJitsi = try container.decodeIfPresent(VectorWellKnownJitsiConfiguration.self, forKey: .deprecatedJitsi)
-        // A malformed migration banner section (e.g. not a JSON object) must not prevent the other sections from being parsed.
-        migrationBanner = try? container.decodeIfPresent(VectorWellKnownMigrationBannerConfiguration.self, forKey: .migrationBanner)
-    }
 }
 
 // MARK: - Encryption
@@ -86,7 +76,7 @@ struct VectorWellKnownJitsiConfiguration: Decodable {
 // MARK: - Migration Banner
 
 /// Raw content of the `io.element.migration_banner` Well Known section, used to configure the banner
-/// inviting users to migrate to Element X.
+/// inviting users to migrate to the new app.
 ///
 /// The resolution of the default values is done by `HomeserverConfigurationBuilder`.
 struct VectorWellKnownMigrationBannerConfiguration: Decodable {

--- a/Riot/Modules/Application/LegacyAppDelegate.h
+++ b/Riot/Modules/Application/LegacyAppDelegate.h
@@ -193,6 +193,11 @@ UINavigationControllerDelegate
 
 - (BOOL)presentCompleteSecurityForSession:(MXSession*)mxSession;
 
+/**
+ Check the cross-signing state of the session and present or dismiss the verification banners and alerts accordingly.
+ */
+- (void)checkCrossSigningForSession:(MXSession*)mxSession;
+
 - (void)configureCallManagerIfRequiredForSession:(MXSession *)mxSession;
 
 - (void)authenticationDidComplete;

--- a/Riot/Modules/Home/AllChats/AllChatsCoordinator.swift
+++ b/Riot/Modules/Home/AllChats/AllChatsCoordinator.swift
@@ -116,6 +116,10 @@ class AllChatsCoordinator: NSObject, SplitViewMasterCoordinatorProtocol {
             let versionCheckCoordinator = createVersionCheckCoordinator(withRootViewController: allChatsViewController, bannerPresentrer: allChatsViewController)
             versionCheckCoordinator.start()
             self.add(childCoordinator: versionCheckCoordinator)
+            
+            let migrationBannerCoordinator = createMigrationBannerCoordinator(withRootViewController: allChatsViewController, bannerPresenter: allChatsViewController)
+            migrationBannerCoordinator.start()
+            self.add(childCoordinator: migrationBannerCoordinator)
         }
         
         self.allChatsViewController?.switchSpace(withId: spaceId)
@@ -595,6 +599,12 @@ class AllChatsCoordinator: NSObject, SplitViewMasterCoordinatorProtocol {
                                                               bannerPresenter: bannerPresentrer,
                                                               themeService: ThemeService.shared())
         return versionCheckCoordinator
+    }
+    
+    private func createMigrationBannerCoordinator(withRootViewController rootViewController: UIViewController, bannerPresenter: BannerPresentationProtocol) -> MigrationBannerCoordinator {
+        MigrationBannerCoordinator(rootViewController: rootViewController,
+                                   bannerPresenter: bannerPresenter,
+                                   sessionProvider: { [weak self] in self?.currentMatrixSession })
     }
     
     private func showInviteFriends(from sourceView: UIView?) {

--- a/Riot/Modules/Home/AllChats/AllChatsViewController.swift
+++ b/Riot/Modules/Home/AllChats/AllChatsViewController.swift
@@ -56,6 +56,14 @@ class AllChatsViewController: HomeViewController {
         didSet {
             bannerView?.translatesAutoresizingMaskIntoConstraints = false
             set(tableHeadeView: bannerView)
+
+            if bannerView == nil {
+                // Notify asynchronously: a banner presented from the observer would be set from within this observer.
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self, self.bannerView == nil else { return }
+                    NotificationCenter.default.post(name: .bannerPresenterDidFreeBannerSlot, object: self)
+                }
+            }
         }
     }
     
@@ -800,17 +808,18 @@ extension AllChatsViewController: SpaceMembersCoordinatorDelegate {
 // MARK: - BannerPresentationProtocol
 extension AllChatsViewController: BannerPresentationProtocol {
     /// The priority of the banners sharing the single banner slot. A banner never replaces a banner with a higher priority.
+    /// The migration banner comes first: the verification banner is displayed once the user has closed it.
     private enum BannerPriority: Int, Comparable {
         case versionCheck
-        case migration
         case verificationRequired
-        
+        case migration
+
         init(bannerView: UIView) {
             switch bannerView {
-            case is VerificationRequiredBannerView:
-                self = .verificationRequired
             case is MigrationBannerView:
                 self = .migration
+            case is VerificationRequiredBannerView:
+                self = .verificationRequired
             default:
                 self = .versionCheck
             }

--- a/Riot/Modules/Home/AllChats/AllChatsViewController.swift
+++ b/Riot/Modules/Home/AllChats/AllChatsViewController.swift
@@ -799,11 +799,48 @@ extension AllChatsViewController: SpaceMembersCoordinatorDelegate {
 
 // MARK: - BannerPresentationProtocol
 extension AllChatsViewController: BannerPresentationProtocol {
-    func presentBannerView(_ bannerView: UIView, animated: Bool) {
+    /// The priority of the banners sharing the single banner slot. A banner never replaces a banner with a higher priority.
+    private enum BannerPriority: Int, Comparable {
+        case versionCheck
+        case migration
+        case verificationRequired
+        
+        init(bannerView: UIView) {
+            switch bannerView {
+            case is VerificationRequiredBannerView:
+                self = .verificationRequired
+            case is MigrationBannerView:
+                self = .migration
+            default:
+                self = .versionCheck
+            }
+        }
+        
+        static func < (lhs: BannerPriority, rhs: BannerPriority) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
+    }
+    
+    @discardableResult
+    func presentBannerView(_ bannerView: UIView, animated: Bool) -> Bool {
+        if let currentBannerView = self.bannerView, BannerPriority(bannerView: bannerView) < BannerPriority(bannerView: currentBannerView) {
+            MXLog.debug("[AllChatsViewController] presentBannerView: a banner with a higher priority is already displayed.")
+            return false
+        }
+        
         self.bannerView = bannerView
+        return true
     }
     
     func dismissBannerView(animated: Bool) {
+        self.bannerView = nil
+    }
+    
+    func dismissBannerView(_ bannerView: UIView, animated: Bool) {
+        guard self.bannerView === bannerView else {
+            return
+        }
+        
         self.bannerView = nil
     }
 }
@@ -849,7 +886,8 @@ extension AllChatsViewController: SplitViewMasterViewControllerProtocol {
     }
     
     func presentVerificationRequiredBanner(with session: MXSession) {
-        guard bannerView == nil, VerificationRequiredBannerChecker().canShowBanner(for: session) else {
+        // The verification banner has the highest priority: it can replace any other banner, but must not be presented twice.
+        guard !(bannerView is VerificationRequiredBannerView), VerificationRequiredBannerChecker().canShowBanner(for: session) else {
             return
         }
         

--- a/Riot/Modules/Home/MigrationBanner/MigrationBanner.swift
+++ b/Riot/Modules/Home/MigrationBanner/MigrationBanner.swift
@@ -15,7 +15,8 @@ struct MigrationBanner: View {
     let message: String
     let buttonTitle: String
     let downloadAction: () -> Void
-    
+    let closeAction: () -> Void
+
     var body: some View {
         VStack(alignment: .leading, spacing: 13) {
             HStack(alignment: .top, spacing: 16) {
@@ -24,12 +25,25 @@ struct MigrationBanner: View {
                     .frame(width: 48, height: 48)
                     .clipShape(RoundedRectangle(cornerRadius: 12))
                     .accessibilityHidden(true)
-                
+
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(title)
-                        .font(theme.fonts.headline)
-                        .foregroundStyle(theme.colors.primaryContent)
-                    
+                    HStack(alignment: .top, spacing: 4) {
+                        Text(title)
+                            .font(theme.fonts.headline)
+                            .foregroundStyle(theme.colors.primaryContent)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                        Button(action: closeAction) {
+                            Image(Asset.Images.closeBanner.name)
+                                .renderingMode(.template)
+                                .resizable()
+                                .frame(width: 20, height: 20)
+                                .foregroundStyle(theme.colors.secondaryContent)
+                        }
+                        .accessibilityLabel(VectorL10n.close)
+                        .accessibilityIdentifier("migrationBannerCloseButton")
+                    }
+
                     Text(message)
                         .font(theme.fonts.subheadline)
                         .foregroundStyle(theme.colors.secondaryContent)
@@ -59,13 +73,17 @@ struct MigrationBanner_Previews: PreviewProvider {
     static var previews: some View {
         MigrationBanner(title: VectorL10n.migrationBannerTitle,
                         message: VectorL10n.migrationBannerBody,
-                        buttonTitle: VectorL10n.migrationBannerDownloadButton) { }
+                        buttonTitle: VectorL10n.migrationBannerDownloadButton,
+                        downloadAction: { },
+                        closeAction: { })
             .theme(.light)
             .previewDisplayName("Light")
-        
+
         MigrationBanner(title: VectorL10n.migrationBannerTitle,
                         message: VectorL10n.migrationBannerBody,
-                        buttonTitle: VectorL10n.migrationBannerDownloadButton) { }
+                        buttonTitle: VectorL10n.migrationBannerDownloadButton,
+                        downloadAction: { },
+                        closeAction: { })
             .theme(.dark)
             .preferredColorScheme(.dark)
             .previewDisplayName("Dark")

--- a/Riot/Modules/Home/MigrationBanner/MigrationBanner.swift
+++ b/Riot/Modules/Home/MigrationBanner/MigrationBanner.swift
@@ -1,0 +1,73 @@
+// 
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import SwiftUI
+
+/// A banner inviting the user to migrate to Element X, displayed at the top of the room list.
+struct MigrationBanner: View {
+    @Environment(\.theme) private var theme: ThemeSwiftUI
+    
+    let title: String
+    let message: String
+    let buttonTitle: String
+    let downloadAction: () -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 13) {
+            HStack(alignment: .top, spacing: 16) {
+                Image(Asset.Images.sunsetBannerIcon.name)
+                    .resizable()
+                    .frame(width: 48, height: 48)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .accessibilityHidden(true)
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(theme.fonts.headline)
+                        .foregroundStyle(theme.colors.primaryContent)
+                    
+                    Text(message)
+                        .font(theme.fonts.subheadline)
+                        .foregroundStyle(theme.colors.secondaryContent)
+                }
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            
+            Button(buttonTitle) {
+                downloadAction()
+            }
+            .buttonStyle(PrimaryActionButtonStyle(font: theme.fonts.bodySB))
+            .accessibilityIdentifier("migrationBannerDownloadButton")
+        }
+        .padding(EdgeInsets(top: 12, leading: 12, bottom: 16, trailing: 12))
+        .background(theme.colors.background, in: RoundedRectangle(cornerRadius: 8))
+        .shapedBorder(color: theme.colors.quinaryContent, borderWidth: 1, shape: RoundedRectangle(cornerRadius: 8))
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .accessibilityIdentifier("migrationBanner")
+    }
+}
+
+// MARK: - Previews
+
+struct MigrationBanner_Previews: PreviewProvider {
+    static var previews: some View {
+        MigrationBanner(title: VectorL10n.migrationBannerTitle,
+                        message: VectorL10n.migrationBannerBody,
+                        buttonTitle: VectorL10n.migrationBannerDownloadButton) { }
+            .theme(.light)
+            .previewDisplayName("Light")
+        
+        MigrationBanner(title: VectorL10n.migrationBannerTitle,
+                        message: VectorL10n.migrationBannerBody,
+                        buttonTitle: VectorL10n.migrationBannerDownloadButton) { }
+            .theme(.dark)
+            .preferredColorScheme(.dark)
+            .previewDisplayName("Dark")
+    }
+}

--- a/Riot/Modules/Home/MigrationBanner/MigrationBanner.swift
+++ b/Riot/Modules/Home/MigrationBanner/MigrationBanner.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// A banner inviting the user to migrate to Element X, displayed at the top of the room list.
+/// A banner inviting the user to migrate to the new app, displayed at the top of the room list.
 struct MigrationBanner: View {
     @Environment(\.theme) private var theme: ThemeSwiftUI
     

--- a/Riot/Modules/Home/MigrationBanner/MigrationBannerCoordinator.swift
+++ b/Riot/Modules/Home/MigrationBanner/MigrationBannerCoordinator.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 
-/// Decides when the banner inviting users to migrate to Element X is displayed at the top of the room list,
+/// Decides when the banner inviting users to migrate to the new app is displayed at the top of the room list,
 /// based on the homeserver Well Known configuration (see `HomeserverMigrationBannerConfiguration`).
 ///
 /// The Well Known is refreshed by the SDK at every session start without any notification, so the banner is

--- a/Riot/Modules/Home/MigrationBanner/MigrationBannerCoordinator.swift
+++ b/Riot/Modules/Home/MigrationBanner/MigrationBannerCoordinator.swift
@@ -26,6 +26,8 @@ final class MigrationBannerCoordinator: Coordinator {
     private var bannerView: MigrationBannerView?
     private var bannerHostingController: VectorHostingController?
     private var wellKnownRefreshOperation: MXHTTPOperation?
+    /// Whether the user closed the banner. Only kept in memory for now: the banner comes back on the next app launch.
+    private var isDismissedByUser = false
     
     // MARK: Public
     
@@ -56,17 +58,27 @@ final class MigrationBannerCoordinator: Coordinator {
     func start() {
         NotificationCenter.default.addObserver(self, selector: #selector(sessionStateDidChange(_:)), name: .mxSessionStateDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(applicationDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
-        
+        NotificationCenter.default.addObserver(self, selector: #selector(bannerSlotDidBecomeFree(_:)), name: .bannerPresenterDidFreeBannerSlot, object: nil)
+
         updateBanner()
     }
-    
+
     // MARK: - Private methods
-    
+
     @objc private func sessionStateDidChange(_ notification: Notification) {
         guard let session = notification.object as? MXSession, session === sessionProvider() else {
             return
         }
-        
+
+        updateBanner()
+    }
+
+    @objc private func bannerSlotDidBecomeFree(_ notification: Notification) {
+        guard let presenter = notification.object as AnyObject?, presenter === (bannerPresenter as AnyObject) else {
+            return
+        }
+
+        // Another banner (e.g. the verification one) has been dismissed: present this one if needed.
         updateBanner()
     }
     
@@ -89,28 +101,49 @@ final class MigrationBannerCoordinator: Coordinator {
     private func updateBanner() {
         guard let session = sessionProvider(),
               session.state != .closed,
+              !isDismissedByUser,
               BuildSettings.replacementApp != nil,
               session.vc_homeserverConfiguration().migrationBanner.isEnabled else {
             dismissBannerIfNeeded()
             return
         }
-        
+
         presentBannerIfNeeded()
     }
-    
+
+    private func handleCloseAction() {
+        isDismissedByUser = true
+        dismissBannerIfNeeded()
+
+        // The banner slot is free again: let the verification banner be displayed if the device isn't verified.
+        if let session = sessionProvider() {
+            AppDelegate.theDelegate().checkCrossSigning(for: session)
+        }
+    }
+
     private func presentBannerIfNeeded() {
+        if let bannerView = bannerView, bannerView.superview == nil {
+            // The banner has been replaced by another one with a higher priority, forget it so it can be presented again.
+            self.bannerView = nil
+            self.bannerHostingController = nil
+        }
+
         guard bannerView == nil, let replacementApp = BuildSettings.replacementApp else {
             return
         }
         
         let banner = MigrationBanner(title: VectorL10n.migrationBannerTitle,
                                      message: VectorL10n.migrationBannerBody,
-                                     buttonTitle: VectorL10n.migrationBannerDownloadButton) { [weak self] in
-            guard let self = self else { return }
-            Task { @MainActor in
-                await ReplacementAppStorePresenter.presentStorePage(appStoreID: replacementApp.productID, from: self.rootViewController)
-            }
-        }
+                                     buttonTitle: VectorL10n.migrationBannerDownloadButton,
+                                     downloadAction: { [weak self] in
+                                         guard let self = self else { return }
+                                         Task { @MainActor in
+                                             await ReplacementAppStorePresenter.presentStorePage(appStoreID: replacementApp.productID, from: self.rootViewController)
+                                         }
+                                     },
+                                     closeAction: { [weak self] in
+                                         self?.handleCloseAction()
+                                     })
         
         let hostingController = VectorHostingController(rootView: banner)
         let bannerView = MigrationBannerView()

--- a/Riot/Modules/Home/MigrationBanner/MigrationBannerCoordinator.swift
+++ b/Riot/Modules/Home/MigrationBanner/MigrationBannerCoordinator.swift
@@ -1,0 +1,138 @@
+// 
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import Foundation
+import SwiftUI
+
+/// Decides when the banner inviting users to migrate to Element X is displayed at the top of the room list,
+/// based on the homeserver Well Known configuration (see `HomeserverMigrationBannerConfiguration`).
+///
+/// The Well Known is refreshed by the SDK at every session start without any notification, so the banner is
+/// re-evaluated when the session state changes, and the Well Known is explicitly refreshed when the app comes back to the foreground.
+final class MigrationBannerCoordinator: Coordinator {
+    
+    // MARK: - Properties
+    
+    // MARK: Private
+    
+    private let rootViewController: UIViewController
+    private let bannerPresenter: BannerPresentationProtocol
+    private let sessionProvider: () -> MXSession?
+    
+    private var bannerView: MigrationBannerView?
+    private var bannerHostingController: VectorHostingController?
+    private var wellKnownRefreshOperation: MXHTTPOperation?
+    
+    // MARK: Public
+    
+    // Must be used only internally
+    var childCoordinators: [Coordinator] = []
+    
+    // MARK: - Setup
+    
+    /// - Parameters:
+    ///   - rootViewController: The view controller used to present the App Store page.
+    ///   - bannerPresenter: The object in charge of displaying the banner view.
+    ///   - sessionProvider: Provides the main session, if any. The banner follows the configuration of this session's homeserver.
+    init(rootViewController: UIViewController,
+         bannerPresenter: BannerPresentationProtocol,
+         sessionProvider: @escaping () -> MXSession?) {
+        self.rootViewController = rootViewController
+        self.bannerPresenter = bannerPresenter
+        self.sessionProvider = sessionProvider
+    }
+    
+    deinit {
+        wellKnownRefreshOperation?.cancel()
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    // MARK: - Public methods
+    
+    func start() {
+        NotificationCenter.default.addObserver(self, selector: #selector(sessionStateDidChange(_:)), name: .mxSessionStateDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(applicationDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+        
+        updateBanner()
+    }
+    
+    // MARK: - Private methods
+    
+    @objc private func sessionStateDidChange(_ notification: Notification) {
+        guard let session = notification.object as? MXSession, session === sessionProvider() else {
+            return
+        }
+        
+        updateBanner()
+    }
+    
+    @objc private func applicationDidBecomeActive() {
+        guard let session = sessionProvider() else {
+            return
+        }
+        
+        // The SDK doesn't refresh the Well Known when resuming, do it so a configuration change on the homeserver is applied quickly.
+        wellKnownRefreshOperation?.cancel()
+        wellKnownRefreshOperation = session.refreshHomeserverWellknown({ [weak self] _ in
+            self?.wellKnownRefreshOperation = nil
+            self?.updateBanner()
+        }, failure: { [weak self] error in
+            self?.wellKnownRefreshOperation = nil
+            MXLog.warning("[MigrationBannerCoordinator] Failed to refresh the homeserver Well Known: \(String(describing: error))")
+        })
+    }
+    
+    private func updateBanner() {
+        guard let session = sessionProvider(),
+              session.state != .closed,
+              BuildSettings.replacementApp != nil,
+              session.vc_homeserverConfiguration().migrationBanner.isEnabled else {
+            dismissBannerIfNeeded()
+            return
+        }
+        
+        presentBannerIfNeeded()
+    }
+    
+    private func presentBannerIfNeeded() {
+        guard bannerView == nil, let replacementApp = BuildSettings.replacementApp else {
+            return
+        }
+        
+        let banner = MigrationBanner(title: VectorL10n.migrationBannerTitle,
+                                     message: VectorL10n.migrationBannerBody,
+                                     buttonTitle: VectorL10n.migrationBannerDownloadButton) { [weak self] in
+            guard let self = self else { return }
+            Task { @MainActor in
+                await ReplacementAppStorePresenter.presentStorePage(appStoreID: replacementApp.productID, from: self.rootViewController)
+            }
+        }
+        
+        let hostingController = VectorHostingController(rootView: banner)
+        let bannerView = MigrationBannerView()
+        bannerView.contentView = hostingController.view
+        
+        guard bannerPresenter.presentBannerView(bannerView, animated: true) else {
+            // Another banner with a higher priority is displayed, the presentation will be retried on the next update.
+            MXLog.debug("[MigrationBannerCoordinator] Banner not presented, another banner is displayed.")
+            return
+        }
+        
+        self.bannerHostingController = hostingController
+        self.bannerView = bannerView
+    }
+    
+    private func dismissBannerIfNeeded() {
+        guard let bannerView = bannerView else {
+            return
+        }
+        
+        bannerPresenter.dismissBannerView(bannerView, animated: true)
+        self.bannerView = nil
+        self.bannerHostingController = nil
+    }
+}

--- a/Riot/Modules/Home/MigrationBanner/MigrationBannerView.swift
+++ b/Riot/Modules/Home/MigrationBanner/MigrationBannerView.swift
@@ -1,0 +1,28 @@
+// 
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import UIKit
+
+/// UIKit container of the `MigrationBanner` SwiftUI view, so it can be presented through `BannerPresentationProtocol`
+/// and identified among the other banners.
+final class MigrationBannerView: UIView {
+    var contentView: UIView? {
+        didSet {
+            oldValue?.removeFromSuperview()
+            if let contentView = contentView {
+                addSubview(contentView)
+                contentView.translatesAutoresizingMaskIntoConstraints = false
+                NSLayoutConstraint.activate([
+                    leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                    trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                    topAnchor.constraint(equalTo: contentView.topAnchor),
+                    bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+                ])
+            }
+        }
+    }
+}

--- a/Riot/Modules/Home/VersionCheck/BannerPresentationProtocol.swift
+++ b/Riot/Modules/Home/VersionCheck/BannerPresentationProtocol.swift
@@ -8,6 +8,14 @@
 import Foundation
 
 @objc protocol BannerPresentationProtocol {
-    func presentBannerView(_ bannerView: UIView, animated: Bool)
+    /// Present the given banner view.
+    /// - Returns: `true` if the banner is displayed, `false` if it has been rejected because another banner with a higher priority is displayed.
+    @discardableResult
+    func presentBannerView(_ bannerView: UIView, animated: Bool) -> Bool
+    
+    /// Dismiss the currently displayed banner view, whatever it is.
     func dismissBannerView(animated: Bool)
+    
+    /// Dismiss the given banner view, only if it is the one currently displayed.
+    func dismissBannerView(_ bannerView: UIView, animated: Bool)
 }

--- a/Riot/Modules/Home/VersionCheck/BannerPresentationProtocol.swift
+++ b/Riot/Modules/Home/VersionCheck/BannerPresentationProtocol.swift
@@ -19,3 +19,9 @@ import Foundation
     /// Dismiss the given banner view, only if it is the one currently displayed.
     func dismissBannerView(_ bannerView: UIView, animated: Bool)
 }
+
+extension Notification.Name {
+    /// Posted by a `BannerPresentationProtocol` implementation once its banner slot becomes free,
+    /// so that a banner previously rejected because of its lower priority can be presented.
+    static let bannerPresenterDidFreeBannerSlot = Notification.Name("BannerPresenterDidFreeBannerSlot")
+}

--- a/Riot/Modules/Home/VersionCheck/HomeViewControllerWithBannerWrapperViewController.swift
+++ b/Riot/Modules/Home/VersionCheck/HomeViewControllerWithBannerWrapperViewController.swift
@@ -57,7 +57,8 @@ class HomeViewControllerWithBannerWrapperViewController: UIViewController, MXKVi
         
     // MARK: - BannerPresentationProtocol
     
-    func presentBannerView(_ bannerView: UIView, animated: Bool) {
+    @discardableResult
+    func presentBannerView(_ bannerView: UIView, animated: Bool) -> Bool {
         bannerView.alpha = 0.0
         bannerView.isHidden = true
         self.stackView.insertArrangedSubview(bannerView, at: 0)
@@ -68,6 +69,8 @@ class HomeViewControllerWithBannerWrapperViewController: UIViewController, MXKVi
             bannerView.isHidden = false
             self.stackView.layoutIfNeeded()
         }
+        
+        return true
     }
     
     func dismissBannerView(animated: Bool) {
@@ -82,6 +85,14 @@ class HomeViewControllerWithBannerWrapperViewController: UIViewController, MXKVi
         } completion: { _ in
             bannerView.removeFromSuperview()
         }
+    }
+    
+    func dismissBannerView(_ bannerView: UIView, animated: Bool) {
+        guard stackView.arrangedSubviews.count > 1, self.stackView.arrangedSubviews.first === bannerView else {
+            return
+        }
+        
+        dismissBannerView(animated: animated)
     }
     
     // MARK: - MXKViewControllerActivityHandling

--- a/Riot/Utils/ReplacementAppStorePresenter.swift
+++ b/Riot/Utils/ReplacementAppStorePresenter.swift
@@ -8,13 +8,13 @@
 import StoreKit
 import UIKit
 
-/// Presents the App Store page of a replacement app (Element X by default), so the user can download it.
+/// Presents the App Store page of the app replacing this one, so the user can download it.
 enum ReplacementAppStorePresenter {
     /// Presents the App Store page of the app with the given App Store ID as a sheet.
     /// Falls back to opening the App Store URL outside of the app if the in-app page can't be shown.
     ///
     /// - Parameters:
-    ///   - appStoreID: The App Store ID (a.k.a. iTunes item identifier) of the app, e.g. `1631335820` for Element X.
+    ///   - appStoreID: The App Store ID (a.k.a. iTunes item identifier) of the app.
     ///   - presenter: The view controller used to present the sheet.
     @MainActor static func presentStorePage(appStoreID: String, from presenter: UIViewController) async {
         do {

--- a/Riot/Utils/ReplacementAppStorePresenter.swift
+++ b/Riot/Utils/ReplacementAppStorePresenter.swift
@@ -1,0 +1,39 @@
+// 
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import StoreKit
+import UIKit
+
+/// Presents the App Store page of a replacement app (Element X by default), so the user can download it.
+enum ReplacementAppStorePresenter {
+    /// Presents the App Store page of the app with the given App Store ID as a sheet.
+    /// Falls back to opening the App Store URL outside of the app if the in-app page can't be shown.
+    ///
+    /// - Parameters:
+    ///   - appStoreID: The App Store ID (a.k.a. iTunes item identifier) of the app, e.g. `1631335820` for Element X.
+    ///   - presenter: The view controller used to present the sheet.
+    @MainActor static func presentStorePage(appStoreID: String, from presenter: UIViewController) async {
+        do {
+            let storeViewController = SKStoreProductViewController()
+            try await storeViewController.loadProduct(withParameters: [SKStoreProductParameterITunesItemIdentifier: appStoreID])
+            presenter.present(storeViewController, animated: true)
+        } catch {
+            // Open the app store URL outside of the app as a fallback.
+            MXLog.warning("[ReplacementAppStorePresenter] Unable to open the in-app store product page: \(error)")
+            guard let appStoreURL = appStoreURL(for: appStoreID) else {
+                MXLog.error("[ReplacementAppStorePresenter] Invalid App Store ID.")
+                return
+            }
+            await UIApplication.shared.open(appStoreURL)
+        }
+    }
+    
+    /// The App Store URL of the app with the given App Store ID.
+    static func appStoreURL(for appStoreID: String) -> URL? {
+        URL(string: "https://apps.apple.com/app/id\(appStoreID)")
+    }
+}

--- a/RiotSwiftUI/Modules/Authentication/Registration/Coordinator/AuthenticationRegistrationCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/Registration/Coordinator/AuthenticationRegistrationCoordinator.swift
@@ -7,7 +7,6 @@
 
 import CommonKit
 import MatrixSDK
-import StoreKit
 import SwiftUI
 
 struct AuthenticationRegistrationCoordinatorParameters {
@@ -294,16 +293,8 @@ final class AuthenticationRegistrationCoordinator: Coordinator, Presentable {
         authenticationRegistrationViewModel.update(homeserver: homeserver.viewData)
     }
     
-    /// Presets the App Store page for the replacement app as a sheet.
+    /// Presents the App Store page for the replacement app as a sheet.
     @MainActor private func showReplacementAppStorePage(_ replacementApp: BuildSettings.ReplacementApp) async {
-        do {
-            let storeViewController = SKStoreProductViewController()
-            try await storeViewController.loadProduct(withParameters: [SKStoreProductParameterITunesItemIdentifier: replacementApp.productID])
-            authenticationRegistrationHostingController.present(storeViewController, animated: true)
-        } catch {
-            // Open the app store URL outside of the app as a fallback.
-            MXLog.warning("Unable to open the in-app store product page: \(error)")
-            await UIApplication.shared.open(replacementApp.appStoreURL)
-        }
+        await ReplacementAppStorePresenter.presentStorePage(appStoreID: replacementApp.productID, from: authenticationRegistrationHostingController)
     }
 }

--- a/RiotSwiftUI/Modules/Authentication/ServerSelection/Coordinator/AuthenticationServerSelectionCoordinator.swift
+++ b/RiotSwiftUI/Modules/Authentication/ServerSelection/Coordinator/AuthenticationServerSelectionCoordinator.swift
@@ -6,7 +6,6 @@
 //
 
 import CommonKit
-import StoreKit
 import SwiftUI
 
 struct AuthenticationServerSelectionCoordinatorParameters {
@@ -138,16 +137,8 @@ final class AuthenticationServerSelectionCoordinator: Coordinator, Presentable {
         }
     }
     
-    /// Presets the App Store page for the replacement app as a sheet.
+    /// Presents the App Store page for the replacement app as a sheet.
     @MainActor private func showReplacementAppStorePage(_ replacementApp: BuildSettings.ReplacementApp) async {
-        do {
-            let storeViewController = SKStoreProductViewController()
-            try await storeViewController.loadProduct(withParameters: [SKStoreProductParameterITunesItemIdentifier: replacementApp.productID])
-            authenticationServerSelectionHostingController.present(storeViewController, animated: true)
-        } catch {
-            // Open the app store URL outside of the app as a fallback.
-            MXLog.warning("Unable to open the in-app store product page: \(error)")
-            await UIApplication.shared.open(replacementApp.appStoreURL)
-        }
+        await ReplacementAppStorePresenter.presentStorePage(appStoreID: replacementApp.productID, from: authenticationServerSelectionHostingController)
     }
 }

--- a/RiotTests/HomeserverMigrationBannerConfigurationTests.swift
+++ b/RiotTests/HomeserverMigrationBannerConfigurationTests.swift
@@ -1,0 +1,75 @@
+// 
+// Copyright 2026 Element Creations Ltd.
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+// Please see LICENSE files in the repository root for full details.
+//
+
+import XCTest
+
+@testable import Element
+
+/// Tests the resolution of the migration banner configuration from the homeserver Well Known.
+class HomeserverMigrationBannerConfigurationTests: XCTestCase {
+    
+    private let startDate = BuildSettings.migrationBannerShowWhenNotConfiguredStartDate
+    private lazy var beforeStartDate = startDate.addingTimeInterval(-1)
+    private lazy var afterStartDate = startDate.addingTimeInterval(24 * 60 * 60)
+    
+    // MARK: - Helpers
+    
+    private func buildConfiguration(migrationBannerSection: Any?, now: Date) -> HomeserverMigrationBannerConfiguration {
+        var wellKnownDictionary: [String: Any] = [
+            "m.homeserver": [
+                "base_url": "https://your.homeserver.org"
+            ]
+        ]
+        if let migrationBannerSection = migrationBannerSection {
+            wellKnownDictionary["io.element.migration_banner"] = migrationBannerSection
+        }
+        
+        let wellKnown = MXWellKnown(fromJSON: wellKnownDictionary)
+        return HomeserverConfigurationBuilder(currentDateProvider: { now }).build(from: wellKnown).migrationBanner
+    }
+    
+    // MARK: - Tests
+    
+    func testStartDate() {
+        let formatter = ISO8601DateFormatter()
+        XCTAssertEqual(formatter.string(from: startDate), "2026-11-15T00:00:00Z")
+    }
+    
+    func testMissingSectionBeforeStartDateIsDisabled() {
+        XCTAssertFalse(buildConfiguration(migrationBannerSection: nil, now: beforeStartDate).isEnabled)
+    }
+    
+    func testMissingSectionFromStartDateIsEnabled() {
+        XCTAssertTrue(buildConfiguration(migrationBannerSection: nil, now: startDate).isEnabled)
+        XCTAssertTrue(buildConfiguration(migrationBannerSection: nil, now: afterStartDate).isEnabled)
+    }
+    
+    func testMissingWellKnownFollowsStartDate() {
+        XCTAssertFalse(HomeserverConfigurationBuilder(currentDateProvider: { self.beforeStartDate }).build(from: nil).migrationBanner.isEnabled)
+        XCTAssertTrue(HomeserverConfigurationBuilder(currentDateProvider: { self.afterStartDate }).build(from: nil).migrationBanner.isEnabled)
+    }
+    
+    func testEmptySectionIsEnabledWhateverTheDate() {
+        XCTAssertTrue(buildConfiguration(migrationBannerSection: [String: Any](), now: beforeStartDate).isEnabled)
+        XCTAssertTrue(buildConfiguration(migrationBannerSection: [String: Any](), now: afterStartDate).isEnabled)
+    }
+    
+    func testExplicitlyEnabledBeforeStartDate() {
+        XCTAssertTrue(buildConfiguration(migrationBannerSection: ["enabled": true], now: beforeStartDate).isEnabled)
+    }
+    
+    func testExplicitlyDisabledAfterStartDate() {
+        XCTAssertFalse(buildConfiguration(migrationBannerSection: ["enabled": false], now: afterStartDate).isEnabled)
+    }
+    
+    func testInvalidSectionIsTreatedAsMissing() {
+        XCTAssertFalse(buildConfiguration(migrationBannerSection: "not an object", now: beforeStartDate).isEnabled)
+        XCTAssertTrue(buildConfiguration(migrationBannerSection: "not an object", now: afterStartDate).isEnabled)
+        XCTAssertFalse(buildConfiguration(migrationBannerSection: ["enabled": "false"], now: beforeStartDate).isEnabled)
+        XCTAssertTrue(buildConfiguration(migrationBannerSection: ["enabled": "false"], now: afterStartDate).isEnabled)
+    }
+}

--- a/RiotTests/VectorWellKnownTests.swift
+++ b/RiotTests/VectorWellKnownTests.swift
@@ -117,36 +117,22 @@ class VectorWellKnownTests: XCTestCase {
         }
     }
     
-    func testMigrationBannerParsingInvalidEnabledValueInvalidatesSection() {
+    func testMigrationBannerParsingInvalidEnabledValueFails() {
         let wellKnownDictionary: [String: Any] = [
             "io.element.migration_banner": [
                 "enabled": "false"
             ]
         ]
         
-        do {
-            let vectorWellKnown: VectorWellKnown = try SerializationService().deserialize(wellKnownDictionary)
-            XCTAssertNil(vectorWellKnown.migrationBanner)
-        } catch {
-            XCTFail("Fail with error: \(error)")
-        }
+        XCTAssertThrowsError(try SerializationService().deserialize(wellKnownDictionary) as VectorWellKnown)
     }
     
-    func testMigrationBannerParsingInvalidSectionDoesNotBreakOtherSections() {
+    func testMigrationBannerParsingInvalidSectionFails() {
         let wellKnownDictionary: [String: Any] = [
-            "io.element.e2ee": [
-                "default": false
-            ],
             "io.element.migration_banner": "not an object"
         ]
         
-        do {
-            let vectorWellKnown: VectorWellKnown = try SerializationService().deserialize(wellKnownDictionary)
-            XCTAssertNil(vectorWellKnown.migrationBanner)
-            XCTAssertEqual(vectorWellKnown.encryption?.isE2EEByDefaultEnabled, false)
-        } catch {
-            XCTFail("Fail with error: \(error)")
-        }
+        XCTAssertThrowsError(try SerializationService().deserialize(wellKnownDictionary) as VectorWellKnown)
     }
     
     func testVectorWellKnownParsingMissingKey() {

--- a/RiotTests/VectorWellKnownTests.swift
+++ b/RiotTests/VectorWellKnownTests.swift
@@ -69,6 +69,86 @@ class VectorWellKnownTests: XCTestCase {
         }
     }        
     
+    func testMigrationBannerParsing() {
+        let wellKnownDictionary: [String: Any] = [
+            "io.element.e2ee": [
+                "default": false
+            ],
+            "io.element.migration_banner": [
+                "enabled": false
+            ]
+        ]
+        
+        do {
+            let vectorWellKnown: VectorWellKnown = try SerializationService().deserialize(wellKnownDictionary)
+            XCTAssertEqual(vectorWellKnown.migrationBanner?.isEnabled, false)
+            XCTAssertEqual(vectorWellKnown.encryption?.isE2EEByDefaultEnabled, false)
+        } catch {
+            XCTFail("Fail with error: \(error)")
+        }
+    }
+    
+    func testMigrationBannerParsingEmptySection() {
+        let wellKnownDictionary: [String: Any] = [
+            "io.element.migration_banner": [String: Any]()
+        ]
+        
+        do {
+            let vectorWellKnown: VectorWellKnown = try SerializationService().deserialize(wellKnownDictionary)
+            XCTAssertNotNil(vectorWellKnown.migrationBanner)
+            XCTAssertNil(vectorWellKnown.migrationBanner?.isEnabled)
+        } catch {
+            XCTFail("Fail with error: \(error)")
+        }
+    }
+    
+    func testMigrationBannerParsingMissingSection() {
+        let wellKnownDictionary: [String: Any] = [
+            "io.element.e2ee": [
+                "default": false
+            ]
+        ]
+        
+        do {
+            let vectorWellKnown: VectorWellKnown = try SerializationService().deserialize(wellKnownDictionary)
+            XCTAssertNil(vectorWellKnown.migrationBanner)
+        } catch {
+            XCTFail("Fail with error: \(error)")
+        }
+    }
+    
+    func testMigrationBannerParsingInvalidEnabledValueInvalidatesSection() {
+        let wellKnownDictionary: [String: Any] = [
+            "io.element.migration_banner": [
+                "enabled": "false"
+            ]
+        ]
+        
+        do {
+            let vectorWellKnown: VectorWellKnown = try SerializationService().deserialize(wellKnownDictionary)
+            XCTAssertNil(vectorWellKnown.migrationBanner)
+        } catch {
+            XCTFail("Fail with error: \(error)")
+        }
+    }
+    
+    func testMigrationBannerParsingInvalidSectionDoesNotBreakOtherSections() {
+        let wellKnownDictionary: [String: Any] = [
+            "io.element.e2ee": [
+                "default": false
+            ],
+            "io.element.migration_banner": "not an object"
+        ]
+        
+        do {
+            let vectorWellKnown: VectorWellKnown = try SerializationService().deserialize(wellKnownDictionary)
+            XCTAssertNil(vectorWellKnown.migrationBanner)
+            XCTAssertEqual(vectorWellKnown.encryption?.isE2EEByDefaultEnabled, false)
+        } catch {
+            XCTFail("Fail with error: \(error)")
+        }
+    }
+    
     func testVectorWellKnownParsingMissingKey() {
                 
         let expectedE2EEEByDefaultEnabled = false


### PR DESCRIPTION
First part of series of PRs to simplify migration from Element Classic to Element X.
This one adds a new banner to the AllChatsScreen for migration purposes, which can be enabled or disabled through well known, or after a specific date where migration will always be suggested (if not specifically disabled).

The content of the banner can be set through the wellknown, but this is part of the next PR work.

fixes https://github.com/element-hq/element-ios/issues/8031